### PR TITLE
Meta -> Subtitle Migrator

### DIFF
--- a/src/Migrator/General/SubtitleMigrator.php
+++ b/src/Migrator/General/SubtitleMigrator.php
@@ -152,6 +152,7 @@ class SubtitleMigrator implements InterfaceMigrator {
 			$subtitle          = get_post_meta( $post->ID, esc_sql( $meta_key ), true );
 			if ( empty( $subtitle ) ) {
 				WP_CLI::warning( sprintf( 'Existing subtitle on %d is empty. Skipping.', $post->ID ) );
+				continue;
 			}
 
 			$newspack_subtitle = ( ! $dry_run ) ? update_post_meta( $post->ID, 'newspack_post_subtitle', esc_sql( $subtitle ) ) : true;

--- a/src/Migrator/General/SubtitleMigrator.php
+++ b/src/Migrator/General/SubtitleMigrator.php
@@ -59,8 +59,8 @@ class SubtitleMigrator implements InterfaceMigrator {
 				'synopsis'  => [
 					[
 						'type'        => 'positional',
-						'name'        => 'meta_name',
-						'description' => 'The name of the custom field to convert.',
+						'name'        => 'meta-key',
+						'description' => 'Key of the custom field to convert.',
 						'optional'    => false,
 						'repeating'   => false,
 					],
@@ -105,22 +105,30 @@ class SubtitleMigrator implements InterfaceMigrator {
 	public function cmd_migrate_custom_field_to_subtitle( $args, $assoc_args ) {
 
 		// Get the meta key.
-		$meta_name = $args[0];
+		$meta_key = $args[0];
 
 		// Grab the post ID, if there is one.
 		$post_id = isset( $assoc_args[ 'post-id' ] ) ? (int) $assoc_args['post-id'] : false;
 
 		// Grab the posts to convert then.
 		if ( $post_id ) {
-			$posts = [ get_post( $post_id ) ];
+			$posts = is_null( get_post( $post_id ) ) ? [] : [ get_post( $post_id ) ];
 		} else {
 			$posts = get_posts( [
 				'posts_per_page' => -1,
 				'post_status'    => 'any',
-				'meta_query' => [
+				'meta_query'     => [
+					'relation' => 'AND',
 					[
-						'key' => $meta_name,
-					]
+						// Ignore posts without the specified meta key.
+						'key'     => $meta_key,
+						'compare' => 'EXISTS',
+					],
+					[
+						// Exclude posts that already have a subtitle.
+						'key'     => 'newspack_post_subtitle',
+						'compare' => 'NOT EXISTS',
+					],
 				],
 			] );
 		}
@@ -131,23 +139,20 @@ class SubtitleMigrator implements InterfaceMigrator {
 
 		foreach ( $posts as $post ) {
 
-			// Skip if there is already an excerpt.
-			if ( ! empty( $post->post_excerpt ) ) {
-				continue;
+			$subtitle          = get_post_meta( $post->ID, esc_sql( $meta_key ), true );
+			$newspack_subtitle = update_post_meta( $post->ID, 'newspack_post_subtitle', esc_sql( $subtitle ) );
+
+			if ( ! $newspack_subtitle ) {
+				WP_CLI::warning( sprintf( 'Failed to update subtitle on %d', $post->ID ) );
+			} else {
+				WP_CLI::success( sprintf( 'Migrated subtitle on post %d', $post->ID ) );
+				add_post_meta( $post->ID, 'np_subtitle_migration', sprintf(
+					'Migrated subtitle "%s" from meta key "%s" at %s.',
+					esc_sql( $subtitle ),
+					esc_sql( $meta_key ),
+					date('c')
+				) );
 			}
-
-			// Already got a Newspack subtitle? Skip it!
-			if ( ! empy( get_post_meta( $post->ID, 'newspack_post_subtitle', true ) ) ) {
-				continue;
-			}
-
-			$subtitle = get_post_meta( $post->ID, $meta_name, true );
-			$newspack = udpate_post_meta( $post->ID, 'newspack_post_subtitle', $subtitle );
-
-			WP_CLI::success( sprintf(
-				'Migrated subtitle on post %d',
-				$post->ID
-			) );
 
 		}
 

--- a/src/Migrator/General/SubtitleMigrator.php
+++ b/src/Migrator/General/SubtitleMigrator.php
@@ -160,7 +160,8 @@ class SubtitleMigrator implements InterfaceMigrator {
 				WP_CLI::warning( sprintf( 'Failed to update subtitle on %d', $post->ID ) );
 			} else {
 				$log_message = sprintf(
-					'Migrated subtitle "%s" from meta key "%s" at %s.',
+					'Migrated subtitle on post %d: "%s" from meta key "%s" at %s.',
+					$post->ID,
 					esc_sql( $subtitle ),
 					esc_sql( $meta_key ),
 					date('c')

--- a/src/Migrator/General/SubtitleMigrator.php
+++ b/src/Migrator/General/SubtitleMigrator.php
@@ -149,7 +149,7 @@ class SubtitleMigrator implements InterfaceMigrator {
 
 		foreach ( $posts as $post ) {
 
-			$subtitle          = get_post_meta( $post->ID, esc_sql( $meta_key ), true );
+			$subtitle = get_post_meta( $post->ID, esc_sql( $meta_key ), true );
 			if ( empty( $subtitle ) ) {
 				WP_CLI::warning( sprintf( 'Existing subtitle on %d is empty. Skipping.', $post->ID ) );
 				continue;

--- a/src/Migrator/General/SubtitleMigrator.php
+++ b/src/Migrator/General/SubtitleMigrator.php
@@ -150,6 +150,10 @@ class SubtitleMigrator implements InterfaceMigrator {
 		foreach ( $posts as $post ) {
 
 			$subtitle          = get_post_meta( $post->ID, esc_sql( $meta_key ), true );
+			if ( empty( $subtitle ) ) {
+				WP_CLI::warning( sprintf( 'Existing subtitle on %d is empty. Skipping.', $post->ID ) );
+			}
+
 			$newspack_subtitle = ( ! $dry_run ) ? update_post_meta( $post->ID, 'newspack_post_subtitle', esc_sql( $subtitle ) ) : true;
 
 			if ( ! $newspack_subtitle ) {


### PR DESCRIPTION
Provides a CLI command to migrate the value of any post meta key to the Newspack subtitle field. This caters for websites storing the subtitle in their own custom meta field, as well as page builders that use meta to store content.

Example usage for a site where the subtitle is stored with meta key of `my_subtitle`:

```
wp newspack-content-migrator migrate-custom-field-to-subtitle my_subtitle
```

Using the dry-run flag will print more detail about what the command will do on a live run:

> Success: Migrated subtitle "- Si disfrutas tus series y películas en el móvil, Netflix habilitó una opción para cambiar la velocidad de reproducción en los terminales Android.\n- Pese a las protestas de directores y actores, esta característica llegó para quedarse." from meta key "subtitulo" at 2021-02-24T14:43:26+00:00.
 
Additionally, the `--verbose` flag will print out in full the new post_content in dry run mode or store it in meta in live run mode.