### PR TITLE
CoAuthors migrator which migrates authors from a meta key

### DIFF
--- a/src/Migrator/General/CoAuthorPlusMigrator.php
+++ b/src/Migrator/General/CoAuthorPlusMigrator.php
@@ -552,6 +552,15 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 				}
 			}
 
+			// Check by username.
+			if ( ! $guest_author ) {
+				$author_username = sanitize_title( $byline_author );
+				$potential_author = $coauthors_plus->guest_authors->get_guest_author_by( 'user_login', $author_username, true );
+				if ( $potential_author ) {
+					$guest_author = $potential_author;
+				}
+			}
+
 			// Create co-author if not exists.
 			if ( ! $guest_author ) {
 				WP_CLI::warning( 'Creating guest author: ' . $byline_author );
@@ -567,7 +576,7 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 						$byline_author
 					) );
 				}
-				$guest_author = $coauthors_guest_authors->get_guest_author_by( 'id', $author_id );
+				$guest_author = $coauthors_guest_authors->get_guest_author_by( 'id', $author_id, true );
 			}
 
 			// Assign coauthor to post.


### PR DESCRIPTION
This PR adds a new command to the CoAuthors Plus migrator which creates guest authors based on a meta key. This is directly useful for Largo's custom byline feature, but it should be widely useful any time there is a site with custom byline authors stored in a meta key.

## To test:

1. Add this script somewhere and run it with e.g. `wp eval-file add-random-bylines.php`. This will populate your DB with random bylines.

```
<?php

/**
 * Add random bylines to all posts.
 */

$bylines = [
	'Bob Bobbington',
	'Jim Jimmington',
	'Fred Freddington',
	'Steve Stevington',
	'Bart Bartington',
	'Ban Bananington',
	'Cat Doggington',
	'Madonna',
	'Claudiu Test',
	'',
];

$meta_key = 'largo_byline_text';

$post_ids = get_posts( [
	'posts_per_page' => -1,
	'fields' => 'ids',
] );

foreach ( $post_ids as $post_id ) {
	$byline = $bylines[ array_rand( $bylines ) ];
	if ( empty( $byline ) ) {
		WP_CLI::warning( "Leaving " . $post_id . "alone" );
		continue;
	}
	WP_CLI::warning( "Assigning " . $byline . " to post " . $post_id );
	update_post_meta( $post_id, $meta_key, $byline );
}
```

2. Run `wp newspack-content-migrator co-authors-meta-to-guest-authors --meta_key=largo_byline_text`. You should see a bunch of output detailing what's going on, and the output should look correct. Examine the posts on the frontend and confirm guest authors were successfully created/assigned.

3. Run `wp newspack-content-migrator co-authors-meta-to-guest-authors --meta_key=largo_byline_text` again. It should correctly recognize that the guest authors have already been assigned to the posts.