### PR TITLE
Clean up Update Recipe

### DIFF
--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -167,57 +167,46 @@ function back_up_staging_site_db() {
 
 function export_staging_site_pages() {
   wp_cli newspack-content-migrator export-all-staging-pages --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_STAGING_PAGES
 }
 
 function export_staging_site_menus() {
   wp_cli newspack-content-migrator export-menus --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_STAGING_MENUS
 }
 
 function export_staging_site_custom_css() {
   wp_cli newspack-content-migrator export-current-theme-custom-css --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_CUSTOM_CSS
 }
 
 function export_staging_site_page_settings() {
   wp_cli newspack-content-migrator export-pages-settings --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_PAGES_SETTINGS
 }
 
 function export_staging_site_identity_settings() {
   wp_cli newspack-content-migrator export-customize-site-identity-settings --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_PAGES_IDENTITY_SETTINGS
 }
 
 function export_staging_site_donation_products() {
   wp_cli newspack-content-migrator export-reader-revenue --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_DONATION_PRODUCTS
 }
 
 function export_staging_site_listings() {
   wp_cli newspack-content-migrator export-listings --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_LISTINGS
 }
 
 function export_staging_site_campaigns() {
   wp_cli newspack-content-migrator export-campaigns --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_CAMPAIGNS
 }
 
 function export_staging_site_ads() {
   wp_cli newspack-content-migrator export-ads --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_ADS
 }
 
 function export_staging_site_newsletters() {
   wp_cli newspack-content-migrator export-newsletters --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_NEWSLETTERS
 }
 
 function export_staging_site_reusable_blocks() {
   wp_cli newspack-content-migrator export-reusable-blocks --output-dir=$TEMP_DIR_MIGRATOR
-  set_var_by_previous_exit_code IS_EXPORTED_REUSABLE_BLOCKS
 }
 
 function export_staging_site_sportspress_plugin_contents() {

--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -61,24 +61,39 @@ function download_vip_search_replace() {
 }
 
 # Sets config variables which can be automatically set.
-function set_auto_config_variables() {
-  set_db_name
-  set_jetpack_table_prefix
-}
+function set_config_variables() {
+  THIS_PLUGINS_NAME='newspack-custom-content-migrator'
+  # Tables to import fully from the Live Site, given here without the table prefix.
+  declare -a IMPORT_TABLES=(commentmeta comments links postmeta posts term_relationships term_taxonomy termmeta terms usermeta users)
+  # If left empty, the DB_NAME_LOCAL will be fetched from the user name, as the Atomic sites' convention.
+  DB_NAME_LOCAL=""
+  # Atomic DB host.
+  DB_HOST_LOCAL=127.0.0.1
+  # Path to the public folder. No ending slash.
+  HTDOCS_PATH=/srv/htdocs
+  # Atomic WP CLI params.
+  WP_CLI_BIN=/usr/local/bin/wp-cli
+  WP_CLI_PATH=/srv/htdocs/__wp__/
+  # If this var is left empty, the VIP's search-replace tool will be downloaded from
+  # https://github.com/Automattic/go-search-replace, otherwise full path to binary.
+  SEARCH_REPLACE=""
 
-# If a specific value is given to the JETPACK_TABLE_PREFIX var, means that the Jetpack Rewind
-# archive contains a different table prefix than the Staging/Launch site. But if it's not set,
-# use TABLE_PREFIX value everywhere.
-function set_jetpack_table_prefix() {
-  if [ "" = "$JETPACK_TABLE_PREFIX" ]; then
-    JETPACK_TABLE_PREFIX=$TABLE_PREFIX
-  fi
-}
+  # Migrators' output dir.
+  TEMP_DIR_MIGRATOR=$TEMP_DIR/migration_exports
+  # Jetpack Rewind temp dir.
+  TEMP_DIR_JETPACK=$TEMP_DIR/jetpack_archive
+  # Another Jetpack temp dir, where the archive initially gets extracted to.
+  TEMP_DIR_JETPACK_UNZIP=$TEMP_DIR_JETPACK/unzip
+  # Name of the Live SQL dump file to save after the hostname replacements are made.
+  LIVE_SQL_DUMP_FILE_REPLACED=$TEMP_DIR/live_db_hostnames_replaced.sql
 
-# Checks the DB_NAME_LOCAL, an if it is empty, it fetches it from the Atomic user name.
-function set_db_name() {
+  # If DB name not provided sets it from the Atomic user name.
   if [ "" = "$DB_NAME_LOCAL" ]; then
     DB_NAME_LOCAL=$( whoami )
+  fi
+  # If not specified otherwise, Jetpack table prefix is the same as local WP DB prefix.
+  if [ "" = "$JETPACK_TABLE_PREFIX" ]; then
+    JETPACK_TABLE_PREFIX=$TABLE_PREFIX
   fi
 }
 

--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -92,6 +92,11 @@ function set_config() {
   if [ "" = "$JETPACK_TABLE_PREFIX" ]; then
     JETPACK_TABLE_PREFIX=$TABLE_PREFIX
   fi
+
+  # Set array with hostname replacements for live SQL dump file before importing it into local.
+  declare -gA LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS
+  LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS[$LIVE_SITE_HOSTNAME]=$STAGING_SITE_HOSTNAME
+  LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS['www.'$LIVE_SITE_HOSTNAME]=$STAGING_SITE_HOSTNAME
 }
 
 function validate_all_params() {

--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -36,27 +36,27 @@ function update_plugin_status() {
   fi
 }
 
-# Checks if SEARCH_REPLACE is set, an if it isn't it downloads the search-replace
-# tool and sets its path.
-function download_vip_search_replace() {
-  # If it's set, use it
-  if [ "" != "$SEARCH_REPLACE" ]; then
-    chmod 755 $SEARCH_REPLACE
-    return
-  fi
-
-  echo_ts 'downloading the search-replace bin...'
-  local ARCHIVE="$TEMP_DIR/search-replace.gz"
+# If the SEARCH_REPLACE file exists it will be used, or else will be downloaded it from GH.
+function get_vip_search_replace() {
+  # Location of search-replace binary.
   SEARCH_REPLACE=$TEMP_DIR/search-replace
-  rm -f $ARCHIVE
-  curl -Ls https://github.com/Automattic/go-search-replace/releases/download/0.0.5/go-search-replace_linux_amd64.gz \
-    -o "$ARCHIVE" && \
-  gzip -f -d $ARCHIVE && \
-  chmod 755 $SEARCH_REPLACE
 
-  if [ ! -f $SEARCH_REPLACE ]; then
-    echo_ts_red 'ERROR: search-replace bin could not be downloaded. You can provide the bin yourself and set it in the SEARCH_REPLACE var.'
-    exit
+  if [ -f $SEARCH_REPLACE ]; then
+    chmod 755 $SEARCH_REPLACE
+    echo_ts "VIP search-replace file found at $SEARCH_REPLACE so it will be used."
+    return
+  else
+    echo_ts 'downloading the search-replace bin...'
+    local ARCHIVE="$TEMP_DIR/search-replace.gz"
+    rm -f $ARCHIVE
+    curl -Ls https://github.com/Automattic/go-search-replace/releases/download/0.0.5/go-search-replace_linux_amd64.gz \
+      -o "$ARCHIVE" && \
+    gzip -f -d $ARCHIVE && \
+    chmod 755 $SEARCH_REPLACE
+    if [ ! -f $SEARCH_REPLACE ]; then
+      echo_ts_red 'ERROR: search-replace bin could not be downloaded. You can provide the bin yourself and save it to $SEARCH_REPLACE'
+      exit
+    fi
   fi
 }
 
@@ -74,9 +74,6 @@ function set_config_variables() {
   # Atomic WP CLI params.
   WP_CLI_BIN=/usr/local/bin/wp-cli
   WP_CLI_PATH=/srv/htdocs/__wp__/
-  # If this var is left empty, the VIP's search-replace tool will be downloaded from
-  # https://github.com/Automattic/go-search-replace, otherwise full path to binary.
-  SEARCH_REPLACE=""
 
   # Migrators' output dir.
   TEMP_DIR_MIGRATOR=$TEMP_DIR/migration_exports

--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -101,7 +101,7 @@ function set_config() {
 
 function validate_all_params() {
   validate_db_connection
-  validate_db_default_charset
+  validate_db_charset
   validate_table_prefix
   validate_live_site_export_variables
   validate_live_db_hostname_replacements
@@ -227,7 +227,7 @@ function replace_hostnames() {
 }
 
 function import_live_sql_dump() {
-  mysql -h $DB_HOST_LOCAL --default-character-set=$DB_DEFAULT_CHARSET ${DB_NAME_LOCAL} < $LIVE_SQL_DUMP_FILE_REPLACED
+  mysql -h $DB_HOST_LOCAL --default-character-set=$DB_CHARSET ${DB_NAME_LOCAL} < $LIVE_SQL_DUMP_FILE_REPLACED
 }
 
 # Syncs files from the live archive.
@@ -249,7 +249,7 @@ function update_files_from_live_site() {
 #	- arg1: output file (full path)
 function dump_db() {
   mysqldump -h $DB_HOST_LOCAL --max_allowed_packet=512M \
-    --default-character-set=$DB_DEFAULT_CHARSET \
+    --default-character-set=$DB_CHARSET \
     $DB_NAME_LOCAL \
     > $1
 }
@@ -326,9 +326,9 @@ function validate_db_connection() {
   fi
 }
 
-function validate_db_default_charset() {
-  if [ 'utf8mb4' != $DB_DEFAULT_CHARSET ] && [ 'utf8' != $DB_DEFAULT_CHARSET ] && [ 'latin1' != $DB_DEFAULT_CHARSET ]; then
-    echo_ts_red 'ERROR: DB_DEFAULT_CHARSET does not have a correct value.'
+function validate_db_charset() {
+  if [ 'utf8mb4' != $DB_CHARSET ] && [ 'utf8' != $DB_CHARSET ] && [ 'latin1' != $DB_CHARSET ]; then
+    echo_ts_red 'ERROR: DB_CHARSET does not have a correct value.'
     exit
   fi
 }
@@ -390,23 +390,23 @@ function validate_live_db_hostname_replacements() {
 # Echoes a green string with a timestamp.
 # - arg1: echo string
 function echo_ts() {
-  GREEN=`tput setaf 2; tput setab 0`
-  RESET_COLOR=`tput sgr0`
+  GREEN=`tput -T xterm-256color setaf 2; tput -T xterm-256color setab 0`
+  RESET_COLOR=`tput -T xterm-256color sgr0`
   echo -e "${GREEN}- [`date +%H:%M:%S`] $@ ${RESET_COLOR}"
 }
 
 # Same like echo_ts, only uses red color.
 # - arg1: echo string
 function echo_ts_red() {
-  RED=`tput setaf 1; tput setab 0`
-  RESET_COLOR=`tput sgr0`
+  RED=`tput -T xterm-256color setaf 1; tput -T xterm-256color setab 0`
+  RESET_COLOR=`tput -T xterm-256color sgr0`
   echo -e "${RED}- [`date +%H:%M:%S`] $@ ${RESET_COLOR}"
 }
 
 # Same like echo_ts, only uses color yellow.
 # - arg1: echo string
 function echo_ts_yellow() {
-  YELLOW=`tput setaf 3; tput setab 0`
-  RESET_COLOR=`tput sgr0`
+  YELLOW=`tput -T xterm-256color setaf 3; tput -T xterm-256color setab 0`
+  RESET_COLOR=`tput -T xterm-256color sgr0`
   echo -e "${YELLOW}- [`date +%H:%M:%S`] $@ ${RESET_COLOR}"
 }

--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -161,54 +161,6 @@ function jetpack_archive_prepare_files_for_sync() {
   rm -rf $TEMP_DIR_JETPACK_UNZIP
 }
 
-function back_up_staging_site_db() {
-  dump_db ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_DEFAULT_CHARSET}.sql
-}
-
-function export_staging_site_pages() {
-  wp_cli newspack-content-migrator export-all-staging-pages --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_menus() {
-  wp_cli newspack-content-migrator export-menus --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_custom_css() {
-  wp_cli newspack-content-migrator export-current-theme-custom-css --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_page_settings() {
-  wp_cli newspack-content-migrator export-pages-settings --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_identity_settings() {
-  wp_cli newspack-content-migrator export-customize-site-identity-settings --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_donation_products() {
-  wp_cli newspack-content-migrator export-reader-revenue --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_listings() {
-  wp_cli newspack-content-migrator export-listings --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_campaigns() {
-  wp_cli newspack-content-migrator export-campaigns --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_ads() {
-  wp_cli newspack-content-migrator export-ads --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_newsletters() {
-  wp_cli newspack-content-migrator export-newsletters --output-dir=$TEMP_DIR_MIGRATOR
-}
-
-function export_staging_site_reusable_blocks() {
-  wp_cli newspack-content-migrator export-reusable-blocks --output-dir=$TEMP_DIR_MIGRATOR
-}
-
 function export_staging_site_sportspress_plugin_contents() {
   wp_cli newspack-content-migrator export-sportspress-content --output-dir=$TEMP_DIR_MIGRATOR
   set_var_by_previous_exit_code IS_EXPORTED_SPORTSPRESS_PLUGIN_CONTENTS

--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -284,7 +284,7 @@ function import_blocks_content_from_staging_site() {
   wp_cli plugin activate newspack-content-converter
 
   echo_ts "importing block contents from the Staging site..."
-  wp_cli newspack-content-migrator import-blocks-content-from-staging-site --table-prefix=$TABLE_PREFIX
+  wp_cli newspack-content-migrator import-blocks-content-from-staging-site --table-prefix=$TABLE_PREFIX --staging-hostname=$STAGING_SITE_HOSTNAME
 }
 
 function clean_up_options() {

--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -63,15 +63,15 @@ function download_vip_search_replace() {
 # Sets config variables which can be automatically set.
 function set_auto_config_variables() {
   set_db_name
-  set_vaultpress_table_prefix
+  set_jetpack_table_prefix
 }
 
-# If a specific value is given to the VAULTPRESS_TABLE_PREFIX var, means that the VaultPress
+# If a specific value is given to the JETPACK_TABLE_PREFIX var, means that the Jetpack Rewind
 # archive contains a different table prefix than the Staging/Launch site. But if it's not set,
 # use TABLE_PREFIX value everywhere.
-function set_vaultpress_table_prefix() {
-  if [ "" = "$VAULTPRESS_TABLE_PREFIX" ]; then
-    VAULTPRESS_TABLE_PREFIX=$TABLE_PREFIX
+function set_jetpack_table_prefix() {
+  if [ "" = "$JETPACK_TABLE_PREFIX" ]; then
+    JETPACK_TABLE_PREFIX=$TABLE_PREFIX
   fi
 }
 
@@ -94,52 +94,52 @@ function prepare_temp_folders() {
   rm -rf $TEMP_DIR || true
   mkdir -p $TEMP_DIR
   mkdir -p $TEMP_DIR_MIGRATOR
-  mkdir -p $TEMP_DIR_VAULTPRESS
-  mkdir -p $TEMP_DIR_VAULTPRESS_UNZIP
+  mkdir -p $TEMP_DIR_JETPACK
+  mkdir -p $TEMP_DIR_JETPACK_UNZIP
 }
 
-# Extracts the VP archive, and prepares its contents for import.
-function unpack_vaultpress_archive() {
-  if [ "" = "$LIVE_VAULTPRESS_ARCHIVE" ]; then
+# Extracts the Jetpack archive, and prepares its contents for import.
+function unpack_jetpack_archive() {
+  if [ "" = "$LIVE_JETPACK_ARCHIVE" ]; then
     return
   fi
 
-  echo_ts 'unpacking the VaultPress archive and prepare contents for import...'
+  echo_ts 'unpacking the Jetpack Rewind archive and prepare contents for import...'
 
-  echo_ts 'extracting the VaultPress Live site archive...'
-  vaultpress_archive_extract
+  echo_ts 'extracting the Jetpack Rewind Live site archive...'
+  jetpack_archive_extract
 
-  echo_ts "preparing Live SQL dump from the VP export..."
-  vaultpress_archive_prepare_live_sql_dump
+  echo_ts "preparing Live SQL dump from the Jetpack export..."
+  jetpack_archive_prepare_live_sql_dump
   echo_ts "created $LIVE_SQL_DUMP_FILE"
 
-  echo_ts 'preparing the VaultPress export files, leaving only uploads to be synced...'
-  vaultpress_archive_prepare_files_for_sync
+  echo_ts 'preparing the Jetpack Rewind export files, leaving only uploads to be synced...'
+  jetpack_archive_prepare_files_for_sync
   echo_ts "stored files for syncing in $LIVE_HTDOCS_FILES"
 }
 
-function vaultpress_archive_extract() {
-  mkdir -p $TEMP_DIR_VAULTPRESS_UNZIP
-  eval "tar xzf $LIVE_VAULTPRESS_ARCHIVE -C $TEMP_DIR_VAULTPRESS_UNZIP > /dev/null 2>&1"
+function jetpack_archive_extract() {
+  mkdir -p $TEMP_DIR_JETPACK_UNZIP
+  eval "tar xzf $LIVE_JETPACK_ARCHIVE -C $TEMP_DIR_JETPACK_UNZIP > /dev/null 2>&1"
   if [ 0 -ne $? ]; then
-    echo_ts_red "error extracting VaultPress archive $LIVE_VAULTPRESS_ARCHIVE."
+    echo_ts_red "error extracting Jetpack Rewind archive $LIVE_JETPACK_ARCHIVE."
     exit
   fi
 }
 
-# Prepares the live SQL dump from the VP export, sets its location to LIVE_SQL_DUMP_FILE
-function vaultpress_archive_prepare_live_sql_dump() {
-  LIVE_SQL_DUMP_FILE=$TEMP_DIR_VAULTPRESS/sql/live.sql
+# Prepares the live SQL dump from the Jetpack export, sets its location to LIVE_SQL_DUMP_FILE
+function jetpack_archive_prepare_live_sql_dump() {
+  LIVE_SQL_DUMP_FILE=$TEMP_DIR_JETPACK/sql/live.sql
 
-  # First get the list of all individual SQL table dump files from the VP SQL export.
+  # First get the list of all individual SQL table dump files from the Jetpack SQL export.
   local LIST_OF_TABLENAMES=""
   for KEY in "${!IMPORT_TABLES[@]}"; do
-    # Using the VAULTPRESS_TABLE_PREFIX var here enables a differet table prefix for the
-    # VP dumps and the Staging/Launch site tables.
-    local TABLE_FILE_FULL_PATH=$TEMP_DIR_VAULTPRESS_UNZIP/sql/$VAULTPRESS_TABLE_PREFIX${IMPORT_TABLES[KEY]}.sql
+    # Using the JETPACK_TABLE_PREFIX var here enables a different table prefix for the
+    # Jetpack dumps and the Staging/Launch site tables.
+    local TABLE_FILE_FULL_PATH=$TEMP_DIR_JETPACK_UNZIP/sql/$JETPACK_TABLE_PREFIX${IMPORT_TABLES[KEY]}.sql
     LIST_OF_TABLENAMES="$LIST_OF_TABLENAMES $TABLE_FILE_FULL_PATH"
 
-    # Also check if table dump exists in the VP export.
+    # Also check if table dump exists in the Jetpack export.
     if [ ! -f $TABLE_FILE_FULL_PATH ]; then
       echo_ts_red "ERROR: Not found table SQL dump $TABLE_FILE_FULL_PATH."
       exit
@@ -147,18 +147,18 @@ function vaultpress_archive_prepare_live_sql_dump() {
   done
 
   # Export all table dumps into the LIVE_SQL_DUMP_FILE file
-  mkdir -p $TEMP_DIR_VAULTPRESS/sql
+  mkdir -p $TEMP_DIR_JETPACK/sql
   cat $LIST_OF_TABLENAMES > $LIVE_SQL_DUMP_FILE
 }
 
-# Prepares files for import from the VP export, sets their location to LIVE_HTDOCS_FILES
-function vaultpress_archive_prepare_files_for_sync() {
-  LIVE_HTDOCS_FILES=$TEMP_DIR_VAULTPRESS/files
+# Prepares files for import from the Jetpack export, sets their location to LIVE_HTDOCS_FILES
+function jetpack_archive_prepare_files_for_sync() {
+  LIVE_HTDOCS_FILES=$TEMP_DIR_JETPACK/files
 
   # Only sync wp-content/uploads, from the LIVE_HTDOCS_FILES
   mkdir -p $LIVE_HTDOCS_FILES/wp-content
-  mv $TEMP_DIR_VAULTPRESS_UNZIP/wp-content/uploads $LIVE_HTDOCS_FILES/wp-content
-  rm -rf $TEMP_DIR_VAULTPRESS_UNZIP
+  mv $TEMP_DIR_JETPACK_UNZIP/wp-content/uploads $LIVE_HTDOCS_FILES/wp-content
+  rm -rf $TEMP_DIR_JETPACK_UNZIP
 }
 
 function back_up_staging_site_db() {
@@ -230,7 +230,7 @@ function prepare_live_sql_dump_for_import() {
   replace_hostnames $LIVE_SQL_DUMP_FILE $LIVE_SQL_DUMP_FILE_REPLACED
 
   echo_ts 'setting `live_` table prefix to all the tables in the Live site SQL dump ...'
-  sed -i "s/\`$VAULTPRESS_TABLE_PREFIX/\`live_$TABLE_PREFIX/g" $LIVE_SQL_DUMP_FILE_REPLACED
+  sed -i "s/\`$JETPACK_TABLE_PREFIX/\`live_$TABLE_PREFIX/g" $LIVE_SQL_DUMP_FILE_REPLACED
 }
 
 # Replace multiple hostnames in a file using the VIP's search-replace tool.
@@ -385,16 +385,16 @@ function validate_table_prefix() {
   fi
 }
 
-# Either LIVE_VAULTPRESS_ARCHIVE must be provided, or both LIVE_HTDOCS_FILES and LIVE_SQL_DUMP_FILE.
+# Either LIVE_JETPACK_ARCHIVE must be provided, or both LIVE_HTDOCS_FILES and LIVE_SQL_DUMP_FILE.
 function validate_live_site_export_variables() {
-  if [ "" != "$LIVE_VAULTPRESS_ARCHIVE" ]; then
-    if [ ! -f $LIVE_VAULTPRESS_ARCHIVE ]; then
-      echo_ts_red "live VaultPress archive not found at location $LIVE_VAULTPRESS_ARCHIVE."
+  if [ "" != "$LIVE_JETPACK_ARCHIVE" ]; then
+    if [ ! -f $LIVE_JETPACK_ARCHIVE ]; then
+      echo_ts_red "live Jetpack Rewind archive not found at location $LIVE_JETPACK_ARCHIVE."
       exit
     fi
   else
     if [ "" = "$LIVE_HTDOCS_FILES" ] && [ "" = "$LIVE_SQL_DUMP_FILE" ]; then
-      echo_ts_red "if LIVE_VAULTPRESS_ARCHIVE config param is not provided, then both LIVE_HTDOCS_FILES and LIVE_SQL_DUMP_FILE must be."
+      echo_ts_red "if LIVE_JETPACK_ARCHIVE config param is not provided, then both LIVE_HTDOCS_FILES and LIVE_SQL_DUMP_FILE must be."
       exit
     else
       validate_live_files

--- a/cli_scripts/inc/functions.sh
+++ b/cli_scripts/inc/functions.sh
@@ -264,9 +264,13 @@ function replace_staging_tables_with_live_tables() {
   done
 }
 
-# Imports previously converted blocks contents from the `staging_ncc_wp_posts_backup`
-# table.
+# Imports previously converted blocks contents from the `staging_wp_posts` table.
 function import_blocks_content_from_staging_site() {
+  if [ "" = "$STAGING_SITE_HOSTNAME" ]; then
+    echo_ts_yellow "Param STAGING_SITE_HOSTNAME not provided, skipping."
+    exit
+  fi
+
   echo_ts "deleting the Newspack Content Converter plugin..."
   wp_cli plugin deactivate newspack-content-converter
   wp_cli plugin delete newspack-content-converter

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -35,7 +35,7 @@ validate_all_config_params
 
 # --- prepare:
 
-download_vip_search_replace
+get_vip_search_replace
 
 echo_ts 'starting to unpack the Jetpack Rewind archive and prepare contents for import...'
 unpack_jetpack_archive

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -141,60 +141,38 @@ replace_staging_tables_with_live_tables
 echo_ts 'activating this plugin after the table switch...'
 wp_cli plugin activate $THIS_PLUGINS_NAME
 
-if [[ 1 == $IS_EXPORTED_STAGING_PAGES ]]; then
-  echo_ts 'importing all Pages from the Staging site and new pages from the Live site...'
-  wp_cli newspack-content-migrator import-staging-site-pages --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing Pages from the Staging site.'; fi
+echo_ts 'importing all Pages from the Staging site and new pages from the Live site...'
+wp_cli newspack-content-migrator import-staging-site-pages --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_STAGING_MENUS ]]; then
-  echo_ts 'importing Menus from the Staging site...'
-  wp_cli newspack-content-migrator import-menus --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing Menus from the Staging site.'; fi
+echo_ts 'importing Menus from the Staging site...'
+wp_cli newspack-content-migrator import-menus --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_CUSTOM_CSS ]]; then
-  echo_ts 'importing custom CSS from the Staging site...'
-  wp_cli newspack-content-migrator import-custom-css-file --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing custom CSS from the Staging site.'; fi
+echo_ts 'importing custom CSS from the Staging site...'
+wp_cli newspack-content-migrator import-custom-css-file --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_PAGES_SETTINGS ]]; then
-  echo_ts 'importing pages settings from the Staging site...'
-  wp_cli newspack-content-migrator import-pages-settings --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing pages settings from the Staging site.'; fi
+echo_ts 'importing pages settings from the Staging site...'
+wp_cli newspack-content-migrator import-pages-settings --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_PAGES_IDENTITY_SETTINGS ]]; then
-  echo_ts 'importing identity settings from the Staging site...'
-  wp_cli newspack-content-migrator import-customize-site-identity-settings --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing pages settings from the Staging site.'; fi
+echo_ts 'importing identity settings from the Staging site...'
+wp_cli newspack-content-migrator import-customize-site-identity-settings --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_DONATION_PRODUCTS ]]; then
-  echo_ts 'importing reader revenue products from the Staging site...'
-  wp_cli newspack-content-migrator import-reader-revenue --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing reader revenue products from the Staging site.'; fi
+echo_ts 'importing reader revenue products from the Staging site...'
+wp_cli newspack-content-migrator import-reader-revenue --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_LISTINGS ]]; then
-  echo_ts 'importing listings from the Staging site...'
-  wp_cli newspack-content-migrator import-listings --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing listings from the Staging site.'; fi
+echo_ts 'importing listings from the Staging site...'
+wp_cli newspack-content-migrator import-listings --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_CAMPAIGNS ]]; then
-  echo_ts 'importing campaigns from the Staging site...'
-  wp_cli newspack-content-migrator import-campaigns --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing Newspack Campaigns from the Staging site.'; fi
+echo_ts 'importing campaigns from the Staging site...'
+wp_cli newspack-content-migrator import-campaigns --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_ADS ]]; then
-  echo_ts 'importing ads from the Staging site...'
-  wp_cli newspack-content-migrator import-ads --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing Ads from the Staging site.'; fi
+echo_ts 'importing ads from the Staging site...'
+wp_cli newspack-content-migrator import-ads --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_NEWSLETTERS ]]; then
-  echo_ts 'importing newsletters from the Staging site...'
-  wp_cli newspack-content-migrator import-newsletters --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing Newsletters from the Staging site.'; fi
+echo_ts 'importing newsletters from the Staging site...'
+wp_cli newspack-content-migrator import-newsletters --input-dir=$TEMP_DIR_MIGRATOR
 
-if [[ 1 == $IS_EXPORTED_REUSABLE_BLOCKS ]]; then
-  echo_ts 'importing Reusable Blocks from the Staging site...'
-  wp_cli newspack-content-migrator import-reusable-blocks --input-dir=$TEMP_DIR_MIGRATOR
-else echo_ts_yellow 'Skipping importing Reusable Blocks from the Staging site.'; fi
+echo_ts 'importing Reusable Blocks from the Staging site...'
+wp_cli newspack-content-migrator import-reusable-blocks --input-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts 'importing Staging content previously converted to blocks...'
 import_blocks_content_from_staging_site

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -4,7 +4,7 @@
 # Local WP DB table prefix.
 TABLE_PREFIX=wp_
 # The --default-character-set param for mysql commands: utf8, utf8mb4, latin1.
-DB_DEFAULT_CHARSET=utf8mb4
+DB_CHARSET=utf8mb4
 # To provide content from the Live site:
 #   1. either set location of LIVE_JETPACK_ARCHIVE,
 #   2. or set both LIVE_HTDOCS_FILES and LIVE_SQL_DUMP_FILE, and leave LIVE_JETPACK_ARCHIVE empty,
@@ -16,11 +16,10 @@ LIVE_SQL_DUMP_FILE=""
 LIVE_SITE_HOSTNAME=""
 # Staging site hostname -- site from which this site was cloned, e.g. "publisher-staging.newspackstaging.com".
 STAGING_SITE_HOSTNAME=""
-# Leave this empty in most case. In rare cases where the Live site uses a different table prefix than this local site, set the Live prefix here.
-JETPACK_TABLE_PREFIX=""
 # Temp folder for this script to run -- ! WARNING ! this folder will be deleted and completely purged.
 TEMP_DIR=/tmp/launch/temp
-
+# Leave this empty in most cases. In rare cases where the Live site uses a different table prefix than this local site, set the Live prefix here.
+JETPACK_TABLE_PREFIX=""
 
 # ---------- ... OR PROVIDED BY CLI PARAMETERS, WHICH THEN OVERRIDE THE ASSIGNMENTS ABOVE :
 while true; do
@@ -29,16 +28,11 @@ while true; do
     --live-hostname ) LIVE_SITE_HOSTNAME="$2"; shift 2 ;;
     --live-jp-archive ) LIVE_JETPACK_ARCHIVE="$2"; shift 2 ;;
     --table-prefix ) TABLE_PREFIX="$2"; shift 2 ;;
-    --db-charset ) DB_DEFAULT_CHARSET="$2"; shift 2 ;;
+    --db-charset ) DB_CHARSET="$2"; shift 2 ;;
     --temp-dir ) TEMP_DIR="$2"; shift 2 ;;
     * ) break ;;
   esac
 done
-
-echo "TABLE_PREFIX: $TABLE_PREFIX"
-echo "DB_DEFAULT_CHARSET: $DB_DEFAULT_CHARSET ."
-exit;
-
 
 
 # START -----------------------------------------------------------------------------
@@ -62,8 +56,8 @@ unpack_jetpack_archive
 echo_ts "checking $THIS_PLUGINS_NAME plugin status..."
 update_plugin_status
 
-echo_ts "backing up current DB to ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_DEFAULT_CHARSET}.sql..."
-dump_db ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_DEFAULT_CHARSET}.sql
+echo_ts "backing up current DB to ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_CHARSET}.sql..."
+dump_db ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_CHARSET}.sql
 
 # --- export:
 

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -17,7 +17,7 @@ LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS=(
   # [publisher.com]=publisher-launch.newspackstaging.com
   # [www.publisher.com]=publisher-launch.newspackstaging.com
 )
-# Staging's hostname -- site from which this site was cloned, e.g. "publisher-staging.newspackstaging.com".
+# Staging site hostname -- site from which this site was cloned, e.g. "publisher-staging.newspackstaging.com"
 STAGING_SITE_HOSTNAME=""
 # Leave this empty in most case. In rare cases where the Live site uses a different table prefix than this local site, set the Live prefix here.
 JETPACK_TABLE_PREFIX=""
@@ -33,17 +33,17 @@ TIME_START=`date +%s`
 set_config
 validate_all_params
 
-echo_ts 'purging temp folder...'
+echo_ts "purging temp dir $TEMP_DIR ..."
 purge_temp_folders
 
 # --- prepare:
 
 get_vip_search_replace
 
-echo_ts 'starting to unpack the Jetpack Rewind archive and prepare contents for import...'
+echo_ts 'unpacking Jetpack Rewind backup archive and preparing contents for import...'
 unpack_jetpack_archive
 
-echo_ts "checking $THIS_PLUGINS_NAME plugin's status..."
+echo_ts "checking $THIS_PLUGINS_NAME plugin status..."
 update_plugin_status
 
 echo_ts "backing up current DB to ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_DEFAULT_CHARSET}.sql..."
@@ -51,13 +51,13 @@ dump_db ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_DEFAULT_CHARSET}.sql
 
 # --- export:
 
-echo_ts 'exporting Staging site pages...'
+echo_ts 'exporting Staging site Pages...'
 wp_cli newspack-content-migrator export-all-staging-pages --output-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'exporting Staging site menus...'
+echo_ts 'exporting Staging site Menus...'
 wp_cli newspack-content-migrator export-menus --output-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts "exporting Staging site active theme custom CSS..."
+echo_ts "exporting Staging site custom CSS..."
 wp_cli newspack-content-migrator export-current-theme-custom-css --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging pages settings..."
@@ -66,74 +66,74 @@ wp_cli newspack-content-migrator export-pages-settings --output-dir=$TEMP_DIR_MI
 echo_ts "exporting Staging site identity settings..."
 wp_cli newspack-content-migrator export-customize-site-identity-settings --output-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts "exporting Staging site reader revenue and donation products..."
+echo_ts "exporting Staging site Reader Revenue and Donation products..."
 wp_cli newspack-content-migrator export-reader-revenue --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging site Listings..."
 wp_cli newspack-content-migrator export-listings --output-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts "exporting Staging site campaigns..."
+echo_ts "exporting Staging site Campaigns..."
 wp_cli newspack-content-migrator export-campaigns --output-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts "exporting Staging site ads..."
+echo_ts "exporting Staging site Ad units..."
 wp_cli newspack-content-migrator export-ads --output-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts "exporting Staging site newsletters..."
+echo_ts "exporting Staging site Newsletters..."
 wp_cli newspack-content-migrator export-newsletters --output-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts "exporting Reusable blocks..."
+echo_ts "exporting Reusable Blocks..."
 wp_cli newspack-content-migrator export-reusable-blocks --output-dir=$TEMP_DIR_MIGRATOR
 
 # --- import DB:
 
-echo_ts 'preparing Live site SQL dump for import...'
+echo_ts 'preparing Live SQL dump for import...'
 prepare_live_sql_dump_for_import
 
 echo_ts 'importing Live DB tables...'
 import_live_sql_dump
 
-echo_ts 'switching Staging site tables with Live site tables...'
+echo_ts 'switching Staging tables with Live tables...'
 replace_staging_tables_with_live_tables
 
 # --- import Staging site data:
 
-echo_ts 'importing all Pages from the Staging site and new pages from the Live site...'
+echo_ts 'importing Pages from Staging and Live...'
 wp_cli newspack-content-migrator import-staging-site-pages --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing Menus from the Staging site...'
+echo_ts 'importing Menus from Staging...'
 wp_cli newspack-content-migrator import-menus --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing custom CSS from the Staging site...'
+echo_ts 'importing custom CSS from Staging...'
 wp_cli newspack-content-migrator import-custom-css-file --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing pages settings from the Staging site...'
+echo_ts 'importing Pages settings from Staging...'
 wp_cli newspack-content-migrator import-pages-settings --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing identity settings from the Staging site...'
+echo_ts 'importing identity settings from Staging...'
 wp_cli newspack-content-migrator import-customize-site-identity-settings --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing reader revenue products from the Staging site...'
+echo_ts 'importing Reader Revenue products from Staging...'
 wp_cli newspack-content-migrator import-reader-revenue --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing listings from the Staging site...'
+echo_ts 'importing Listings from Staging...'
 wp_cli newspack-content-migrator import-listings --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing campaigns from the Staging site...'
+echo_ts 'importing Campaigns from Staging...'
 wp_cli newspack-content-migrator import-campaigns --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing ads from the Staging site...'
+echo_ts 'importing Ads from Staging...'
 wp_cli newspack-content-migrator import-ads --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing newsletters from the Staging site...'
+echo_ts 'importing Newsletters from Staging...'
 wp_cli newspack-content-migrator import-newsletters --input-dir=$TEMP_DIR_MIGRATOR
 
-echo_ts 'importing Reusable Blocks from the Staging site...'
+echo_ts 'importing Reusable Blocks from Staging...'
 wp_cli newspack-content-migrator import-reusable-blocks --input-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts 'updating WooComm settings...'
 wp_cli newspack-content-migrator woocomm-setup
 
-echo_ts 'importing Staging content previously converted to blocks...'
+echo_ts 'importing content previously converted to blocks from Staging...'
 import_blocks_content_from_staging_site
 
 echo_ts 'syncing files from Live site...'
@@ -141,7 +141,7 @@ update_files_from_live_site
 
 # --- finish:
 
-echo_ts 'cleaning up options...'
+echo_ts 'cleaning up some options...'
 clean_up_options
 
 echo_ts 'updating seo settings...'

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -13,11 +13,13 @@ LIVE_JETPACK_ARCHIVE=/tmp/launch/jetpack_rewind_backup.tar.gz
 LIVE_HTDOCS_FILES=""
 LIVE_SQL_DUMP_FILE=""
 # Hostname replacements to perform on the Live DB dump before importing it. Keys are live hostname, values are this site's hostname:
-declare -A LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS=(
+LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS=(
   # [publisher.com]=publisher-launch.newspackstaging.com
   # [www.publisher.com]=publisher-launch.newspackstaging.com
 )
-# In rare cases that the Live site used a different prefix than this local site, set the Live prefix here, or leave empty.
+# Staging's hostname -- site from which this site was cloned, e.g. "publisher-staging.newspackstaging.com".
+STAGING_SITE_HOSTNAME=""
+# Leave this empty in most case. In rare cases where the Live site uses a different table prefix than this local site, set the Live prefix here.
 JETPACK_TABLE_PREFIX=""
 # Temp folder for this script to run -- ! WARNING ! this folder will be deleted and completely purged.
 TEMP_DIR=/tmp/launch/temp

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# ---------- USER SET VARIABLES:
+# ---------- VARIABLES CAN EITHER BE SET HERE MANUALLY ... :
 # Local WP DB table prefix.
 TABLE_PREFIX=wp_
 # The --default-character-set param for mysql commands: utf8, utf8mb4, latin1.
@@ -12,17 +12,33 @@ DB_DEFAULT_CHARSET=utf8mb4
 LIVE_JETPACK_ARCHIVE=/tmp/launch/jetpack_rewind_backup.tar.gz
 LIVE_HTDOCS_FILES=""
 LIVE_SQL_DUMP_FILE=""
-# Hostname replacements to perform on the Live DB dump before importing it. Keys are live hostname, values are this site's hostname:
-LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS=(
-  # [publisher.com]=publisher-launch.newspackstaging.com
-  # [www.publisher.com]=publisher-launch.newspackstaging.com
-)
-# Staging site hostname -- site from which this site was cloned, e.g. "publisher-staging.newspackstaging.com"
+# Live site hostname without the www. prefix, e.g. publisher.com.
+LIVE_SITE_HOSTNAME=""
+# Staging site hostname -- site from which this site was cloned, e.g. "publisher-staging.newspackstaging.com".
 STAGING_SITE_HOSTNAME=""
 # Leave this empty in most case. In rare cases where the Live site uses a different table prefix than this local site, set the Live prefix here.
 JETPACK_TABLE_PREFIX=""
 # Temp folder for this script to run -- ! WARNING ! this folder will be deleted and completely purged.
 TEMP_DIR=/tmp/launch/temp
+
+
+# ---------- ... OR PROVIDED BY CLI PARAMETERS, WHICH THEN OVERRIDE THE ASSIGNMENTS ABOVE :
+while true; do
+  case "$1" in
+    --staging-hostname ) STAGING_SITE_HOSTNAME="$2"; shift 2 ;;
+    --live-hostname ) LIVE_SITE_HOSTNAME="$2"; shift 2 ;;
+    --live-jp-archive ) LIVE_JETPACK_ARCHIVE="$2"; shift 2 ;;
+    --table-prefix ) TABLE_PREFIX="$2"; shift 2 ;;
+    --db-charset ) DB_DEFAULT_CHARSET="$2"; shift 2 ;;
+    --temp-dir ) TEMP_DIR="$2"; shift 2 ;;
+    * ) break ;;
+  esac
+done
+
+echo "TABLE_PREFIX: $TABLE_PREFIX"
+echo "DB_DEFAULT_CHARSET: $DB_DEFAULT_CHARSET ."
+exit;
+
 
 
 # START -----------------------------------------------------------------------------

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -148,9 +148,8 @@ wp_cli newspack-content-migrator update-seo-settings
 echo_ts 'setting file permissions to public content...'
 set_public_content_file_permissions
 
-# # Recommended to keep these tables for a short while after the launch, for easier problem fixing
-# echo_ts 'dropping temp DB tables (prefixed with `live_` and `staging_`)...'
-# drop_temp_db_tables
+echo_ts 'dropping temp DB tables (prefixed with `live_` and `staging_`)...'
+drop_temp_db_tables
 
 echo_ts 'flushing WP cache...'
 wp_cli cache flush

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -90,42 +90,42 @@ echo_ts "checking $THIS_PLUGINS_NAME plugin's status..."
 update_plugin_status
 
 echo_ts "backing up current DB to ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_DEFAULT_CHARSET}.sql..."
-back_up_staging_site_db
+dump_db ${TEMP_DIR}/${DB_NAME_LOCAL}_backup_${DB_DEFAULT_CHARSET}.sql
 
 # --- export:
 
 echo_ts 'exporting Staging site pages...'
-export_staging_site_pages
+wp_cli newspack-content-migrator export-all-staging-pages --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts 'exporting Staging site menus...'
-export_staging_site_menus
+wp_cli newspack-content-migrator export-menus --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging site active theme custom CSS..."
-export_staging_site_custom_css
+wp_cli newspack-content-migrator export-current-theme-custom-css --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging pages settings..."
-export_staging_site_page_settings
+wp_cli newspack-content-migrator export-pages-settings --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging site identity settings..."
-export_staging_site_identity_settings
+wp_cli newspack-content-migrator export-customize-site-identity-settings --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging site donation products..."
-export_staging_site_donation_products
+wp_cli newspack-content-migrator export-reader-revenue --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging site Listings..."
-export_staging_site_listings
+wp_cli newspack-content-migrator export-listings --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging site campaigns..."
-export_staging_site_campaigns
+wp_cli newspack-content-migrator export-campaigns --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging site ads..."
-export_staging_site_ads
+wp_cli newspack-content-migrator export-ads --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Staging site newsletters..."
-export_staging_site_newsletters
+wp_cli newspack-content-migrator export-newsletters --output-dir=$TEMP_DIR_MIGRATOR
 
 echo_ts "exporting Reusable blocks..."
-export_staging_site_reusable_blocks
+wp_cli newspack-content-migrator export-reusable-blocks --output-dir=$TEMP_DIR_MIGRATOR
 
 # --- import:
 

--- a/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
+++ b/cli_scripts/update_recipes/0_UPDATE_RECIPE_TEMPLATE.sh
@@ -6,16 +6,16 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 # ---------- USER SET VARIABLES:
-# Local DB table prefix. In a rare case when the VaultPress SQL dump uses a different
-# table prefix than the local DB one, you may set it in the VAULTPRESS_TABLE_PREFIX var.
+# Local DB table prefix. In a rare case when the Jetpack Rewind SQL dump uses a different
+# table prefix than the local DB one, you may set it in the JETPACK_TABLE_PREFIX var.
 TABLE_PREFIX=wp_
 # The --default-character-set param for mysql(dump) commands; utf8, utf8mb4, latin1.
 DB_DEFAULT_CHARSET=utf8mb4
 # To provide content for import from the Live site,
-#   1. either set path to VaultPress archive in LIVE_VAULTPRESS_ARCHIVE
+#   1. either set path to Jetpack Rewind archive in LIVE_JETPACK_ARCHIVE
 #   2. or set both LIVE_FILES and LIVE_SQL_DUMP_FILE and leave
-#      LIVE_VAULTPRESS_ARCHIVE as an empty string ( LIVE_VAULTPRESS_ARCHIVE="" ).
-LIVE_VAULTPRESS_ARCHIVE=/tmp/live_export/vaultpress.tar.gz
+#      LIVE_JETPACK_ARCHIVE as an empty string ( LIVE_JETPACK_ARCHIVE="" ).
+LIVE_JETPACK_ARCHIVE=/tmp/live_export/jetpack_rewind_backup.tar.gz
 # Hostname replacements to perform on the Live DB dump before importing it.
 # Associative array with REPLACE_HOST_FROM -> REPLACE_HOST_TO as key-value pairs.
 # Pure host names, no pre- or post-slashes. One replacement per domain or subdomain.
@@ -31,15 +31,15 @@ declare -A LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS=(
 THIS_PLUGINS_NAME='newspack-custom-content-migrator'
 # Temp folder for script's resources. No ending slash. Will be purged.
 TEMP_DIR=/tmp/launch/tmp_update
-# If LIVE_VAULTPRESS_ARCHIVE is given, this var will be set automatically. Otherwise,
+# If LIVE_JETPACK_ARCHIVE is given, this var will be set automatically. Otherwise,
 # set path to the folder containing Live files, no ending slash. Should contain wp-content.
 LIVE_HTDOCS_FILES=""
-# If LIVE_VAULTPRESS_ARCHIVE is given, this var will be set automatically. Otherwise,
+# If LIVE_JETPACK_ARCHIVE is given, this var will be set automatically. Otherwise,
 # set path to Live SQL dump file. This dump should contain only tables from IMPORT_TABLES.
 LIVE_SQL_DUMP_FILE=""
-# Set the VAULTPRESS_TABLE_PREFIX if the VaultPress SQL dump has a different prefix than
+# Set the JETPACK_TABLE_PREFIX if the Jetpack Rewind SQL dump has a different prefix than
 # the local Staging/Launch DB.
-VAULTPRESS_TABLE_PREFIX=""
+JETPACK_TABLE_PREFIX=""
 # Tables to import fully from the Live Site, given here without the table prefix.
 declare -a IMPORT_TABLES=(commentmeta comments links postmeta posts term_relationships term_taxonomy termmeta terms usermeta users)
 # If left empty, the DB_NAME_LOCAL will be fetched from the user name, as a convention on
@@ -59,10 +59,10 @@ SEARCH_REPLACE=""
 # ---------- SCRIPT VARIABLES, do not change these:
 # Migration Plugin's output dir (the Plugin uses hard-coded file names).
 TEMP_DIR_MIGRATOR=$TEMP_DIR/migration_exports
-# VaultPress export temp dir, where the SQL dump and files get extracted to.
-TEMP_DIR_VAULTPRESS=$TEMP_DIR/vaultpress_archive
-# Another VP temp dir, where the archive initially gets extracted to.
-TEMP_DIR_VAULTPRESS_UNZIP=$TEMP_DIR_VAULTPRESS/unzip
+# Jetpack Rewind export temp dir, where the SQL dump and files get extracted to.
+TEMP_DIR_JETPACK=$TEMP_DIR/jetpack_archive
+# Another Jetpack temp dir, where the archive initially gets extracted to.
+TEMP_DIR_JETPACK_UNZIP=$TEMP_DIR_JETPACK/unzip
 # Name of file where to save the Live SQL dump after hostname replacements are made.
 LIVE_SQL_DUMP_FILE_REPLACED=$TEMP_DIR/live_db_hostnames_replaced.sql
 
@@ -83,8 +83,8 @@ validate_all_config_params
 
 download_vip_search_replace
 
-echo_ts 'starting to unpack the VaultPress archive and prepare contents for import...'
-unpack_vaultpress_archive
+echo_ts 'starting to unpack the Jetpack Rewind archive and prepare contents for import...'
+unpack_jetpack_archive
 
 echo_ts "checking $THIS_PLUGINS_NAME plugin's status..."
 update_plugin_status

--- a/src/Migrator/General/AdsMigrator.php
+++ b/src/Migrator/General/AdsMigrator.php
@@ -92,12 +92,12 @@ class AdsMigrator implements InterfaceMigrator {
 
 		$result = $this->export_ads( $output_dir, self::AD_UNITS_EXPORT_FILE );
 		if ( true === $result ) {
+			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
+			WP_CLI::warning( 'Done.' );
 			exit(1);
 		}
-
-		WP_CLI::success( 'Done.' );
 	}
 
 	/**
@@ -139,7 +139,7 @@ class AdsMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::AD_UNITS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $import_file ) );
+			WP_CLI::error( sprintf( 'Ads file not found %s.', $import_file ) );
 		}
 
 		WP_CLI::line( 'Importing Newspack Ads...' );

--- a/src/Migrator/General/AdsMigrator.php
+++ b/src/Migrator/General/AdsMigrator.php
@@ -139,7 +139,8 @@ class AdsMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::AD_UNITS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Ads file not found %s.', $import_file ) );
+			WP_CLI::warning( sprintf( 'Ads file not found %s.', $import_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( 'Importing Newspack Ads from ' . $import_file . ' ...' );

--- a/src/Migrator/General/AdsMigrator.php
+++ b/src/Migrator/General/AdsMigrator.php
@@ -95,7 +95,7 @@ class AdsMigrator implements InterfaceMigrator {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
-			WP_CLI::warning( 'Done.' );
+			WP_CLI::warning( 'Done with warnings.' );
 			exit(1);
 		}
 	}
@@ -142,7 +142,7 @@ class AdsMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Ads file not found %s.', $import_file ) );
 		}
 
-		WP_CLI::line( 'Importing Newspack Ads...' );
+		WP_CLI::line( 'Importing Newspack Ads from ' . $import_file . ' ...' );
 
 		$this->import_ads( $import_file );
 

--- a/src/Migrator/General/CampaignsMigrator.php
+++ b/src/Migrator/General/CampaignsMigrator.php
@@ -95,7 +95,7 @@ class CampaignsMigrator implements InterfaceMigrator {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
-			WP_CLI::warning( 'Done.' );
+			WP_CLI::warning( 'Done with warnings.' );
 			exit(1);
 		}
 	}
@@ -142,7 +142,7 @@ class CampaignsMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Campaigns file not found %s.', $import_file ) );
 		}
 
-		WP_CLI::line( 'Importing Newspack Campaigns...' );
+		WP_CLI::line( 'Importing Newspack Campaigns from ' . $import_file . ' ...' );
 
 		$this->import_campaigns( $import_file );
 

--- a/src/Migrator/General/CampaignsMigrator.php
+++ b/src/Migrator/General/CampaignsMigrator.php
@@ -92,12 +92,12 @@ class CampaignsMigrator implements InterfaceMigrator {
 
 		$result = $this->export_campaigns( $output_dir, self::CAMPAIGNS_EXPORT_FILE );
 		if ( true === $result ) {
+			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
+			WP_CLI::warning( 'Done.' );
 			exit(1);
 		}
-
-		WP_CLI::success( 'Done.' );
 	}
 
 	/**
@@ -139,7 +139,7 @@ class CampaignsMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::CAMPAIGNS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $import_file ) );
+			WP_CLI::error( sprintf( 'Campaigns file not found %s.', $import_file ) );
 		}
 
 		WP_CLI::line( 'Importing Newspack Campaigns...' );

--- a/src/Migrator/General/CampaignsMigrator.php
+++ b/src/Migrator/General/CampaignsMigrator.php
@@ -139,7 +139,8 @@ class CampaignsMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::CAMPAIGNS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Campaigns file not found %s.', $import_file ) );
+			WP_CLI::warning( sprintf( 'Campaigns file not found %s.', $import_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( 'Importing Newspack Campaigns from ' . $import_file . ' ...' );

--- a/src/Migrator/General/ContentConverterPluginMigrator.php
+++ b/src/Migrator/General/ContentConverterPluginMigrator.php
@@ -121,19 +121,18 @@ class ContentConverterPluginMigrator implements InterfaceMigrator {
 
 
 		// Now update hostnames, too.
+		WP_CLI::line( sprintf( 'Updating hostnames in content brought over from Staging from %s to %s ...', $staging_host, $this_host ) );
 		$posts_ids = $this->posts_logic->get_all_posts_ids();
 		foreach ( $posts_ids as $key_posts_ids => $post_id ) {
 			$post                 = get_post( $post_id );
-			$post_content         = $post->post_content;
-			$post_excerpt         = $post->post_excerpt;
 			$post_content_updated = str_replace( $staging_host, $this_host, $post->post_content );
 			$post_excerpt_updated = str_replace( $staging_host, $this_host, $post->post_excerpt );
-			if ( $post_content != $post_content_updated || $post_excerpt != $post_excerpt_updated ) {
+			if ( $post->post_content != $post_content_updated || $post->post_excerpt != $post_excerpt_updated ) {
 				$wpdb->update(
 					$wpdb->prefix . 'posts',
 					[
 						'post_content'  => $post_content_updated,
-						'$post_excerpt' => $post_excerpt_updated,
+						'post_excerpt' => $post_excerpt_updated,
 					],
 					[ 'ID' => $post->ID ]
 				);

--- a/src/Migrator/General/ContentConverterPluginMigrator.php
+++ b/src/Migrator/General/ContentConverterPluginMigrator.php
@@ -3,6 +3,7 @@
 namespace NewspackCustomContentMigrator\Migrator\General;
 
 use \NewspackCustomContentMigrator\Migrator\InterfaceMigrator;
+use \NewspackCustomContentMigrator\MigrationLogic\Posts as PostsLogic;
 use \WP_CLI;
 
 class ContentConverterPluginMigrator implements InterfaceMigrator {
@@ -13,9 +14,15 @@ class ContentConverterPluginMigrator implements InterfaceMigrator {
 	private static $instance = null;
 
 	/**
+	 * @var PostsLogic.
+	 */
+	private $posts_logic;
+
+	/**
 	 * Constructor.
 	 */
 	private function __construct() {
+		$this->posts_logic = new PostsLogic();
 	}
 
 	/**
@@ -46,6 +53,13 @@ class ContentConverterPluginMigrator implements InterfaceMigrator {
 					'optional'    => false,
 					'repeating'   => false,
 				],
+				[
+					'type'        => 'assoc',
+					'name'        => 'staging-hostname',
+					'description' => "Staging site's hostname -- the site from which this site was cloned.",
+					'optional'    => false,
+					'repeating'   => false,
+				],
 			],
 		] );
 	}
@@ -59,13 +73,17 @@ class ContentConverterPluginMigrator implements InterfaceMigrator {
 	public function cmd_import_blocks_content_from_staging_site( $args, $assoc_args ) {
 		$table_prefix = isset( $assoc_args[ 'table-prefix' ] ) ? $assoc_args[ 'table-prefix' ] : null;
 		if ( is_null( $table_prefix ) ) {
-			WP_CLI::error( 'Invalid table prefix.' );
+			WP_CLI::error( 'Invalid table prefix param.' );
+		}
+		$staging_host = isset( $assoc_args[ 'staging-hostname' ] ) ? $assoc_args[ 'staging-hostname' ] : null;
+		if ( is_null( $staging_host ) ) {
+			WP_CLI::error( 'Invalid Staging hostname param.' );
 		}
 
 		global $wpdb;
 
 		$staging_posts_table = $wpdb->dbh->real_escape_string( 'staging_' . $table_prefix . 'posts' );
-		$posts_table = $wpdb->dbh->real_escape_string( $table_prefix . 'posts' );
+		$posts_table         = $wpdb->dbh->real_escape_string( $table_prefix . 'posts' );
 
 		// Check if the backed up posts table from staging exists.
 		$table_count = $wpdb->get_var(
@@ -79,9 +97,18 @@ class ContentConverterPluginMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Table %s not found in DB, skipping importing block contents.', $staging_posts_table ) );
 		}
 
-		WP_CLI::line( 'Importing content previously converted to blocks from the Staging posts table...' );
+		// Get Staging hostname, and this hostname..
+		$this_options_table    = $wpdb->dbh->real_escape_string( $table_prefix . 'options' );
+		$this_siteurl          = $wpdb->get_var( $wpdb->prepare ( "SELECT option_value FROM $this_options_table where option_name = 'siteurl';", $staging_posts_table ) );
+		$url_parse             = wp_parse_url( $this_siteurl );
+		$this_host             = $url_parse[ 'host' ] ?? null;
+		if ( null === $this_host ) {
+			WP_CLI::error( "Could not fetch this site's siteurl from the options table $this_options_table." );
+		}
+
 
 		// Update wp_posts with converted content from the Staging wp_posts backup.
+		WP_CLI::line( 'Importing content previously converted to blocks from the Staging posts table...' );
 		$wpdb->get_results(
 			"UPDATE $posts_table wp
 			JOIN $staging_posts_table swp
@@ -91,6 +118,30 @@ class ContentConverterPluginMigrator implements InterfaceMigrator {
 			SET wp.post_content = swp.post_content
 			WHERE swp.post_content LIKE '<!-- wp:%'; "
 		);
+
+
+		// Now update hostnames, too.
+		$posts_ids = $this->posts_logic->get_all_posts_ids();
+		foreach ( $posts_ids as $key_posts_ids => $post_id ) {
+			$post                 = get_post( $post_id );
+			$post_content         = $post->post_content;
+			$post_excerpt         = $post->post_excerpt;
+			$post_content_updated = str_replace( $staging_host, $this_host, $post->post_content );
+			$post_excerpt_updated = str_replace( $staging_host, $this_host, $post->post_excerpt );
+			if ( $post_content != $post_content_updated || $post_excerpt != $post_excerpt_updated ) {
+				$wpdb->update(
+					$wpdb->prefix . 'posts',
+					[
+						'post_content'  => $post_content_updated,
+						'$post_excerpt' => $post_excerpt_updated,
+					],
+					[ 'ID' => $post->ID ]
+				);
+			}
+		}
+
+		// Required for the $wpdb->update() sink in.
+		wp_cache_flush();
 
 		WP_CLI::success( 'Done.' );
 	}

--- a/src/Migrator/General/CssMigrator.php
+++ b/src/Migrator/General/CssMigrator.php
@@ -85,12 +85,12 @@ class CssMigrator implements InterfaceMigrator {
 
 		$result = $this->export_current_theme_custom_css( $output_dir, self::CSS_CURRENT_THEME_EXPORT_FILE );
 		if ( true === $result ) {
+			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
+			WP_CLI::warning( 'Done.' );
 			exit(1);
 		}
-
-		WP_CLI::success( 'Done.' );
 	}
 
 	/**
@@ -127,7 +127,7 @@ class CssMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::CSS_CURRENT_THEME_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $import_file ) );
+			WP_CLI::error( sprintf( 'CSS file not found %s.', $import_file ) );
 		}
 
 		WP_CLI::line( 'Importing custom CSS...' );

--- a/src/Migrator/General/CssMigrator.php
+++ b/src/Migrator/General/CssMigrator.php
@@ -127,7 +127,8 @@ class CssMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::CSS_CURRENT_THEME_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'CSS file not found %s.', $import_file ) );
+			WP_CLI::warning( sprintf( 'CSS file not found %s.', $import_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( 'Importing custom CSS from ' . $import_file . ' ...' );

--- a/src/Migrator/General/CssMigrator.php
+++ b/src/Migrator/General/CssMigrator.php
@@ -88,7 +88,7 @@ class CssMigrator implements InterfaceMigrator {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
-			WP_CLI::warning( 'Done.' );
+			WP_CLI::warning( 'Done with warnings.' );
 			exit(1);
 		}
 	}
@@ -130,7 +130,7 @@ class CssMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'CSS file not found %s.', $import_file ) );
 		}
 
-		WP_CLI::line( 'Importing custom CSS...' );
+		WP_CLI::line( 'Importing custom CSS from ' . $import_file . ' ...' );
 
 		$this->delete_all_custom_css();
 		PostsMigrator::get_instance()->import_posts( $import_file );

--- a/src/Migrator/General/ListingsMigrator.php
+++ b/src/Migrator/General/ListingsMigrator.php
@@ -101,12 +101,12 @@ class ListingsMigrator implements InterfaceMigrator {
 
 		$result = $this->export_listings( $output_dir, self::LISTINGS_EXPORT_FILE );
 		if ( true === $result ) {
+			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
+			WP_CLI::warning( 'Done.' );
 			exit(1);
 		}
-
-		WP_CLI::success( 'Done.' );
 	}
 
 	/**
@@ -152,7 +152,7 @@ class ListingsMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::LISTINGS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $import_file ) );
+			WP_CLI::error( sprintf( 'Listings file not found %s.', $import_file ) );
 		}
 
 		WP_CLI::line( 'Importing Listings...' );

--- a/src/Migrator/General/ListingsMigrator.php
+++ b/src/Migrator/General/ListingsMigrator.php
@@ -152,7 +152,8 @@ class ListingsMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::LISTINGS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Listings file not found %s.', $import_file ) );
+			WP_CLI::warning( sprintf( 'Listings file not found %s.', $import_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( 'Importing Listings from ' . $import_file . ' ...' );

--- a/src/Migrator/General/ListingsMigrator.php
+++ b/src/Migrator/General/ListingsMigrator.php
@@ -104,7 +104,7 @@ class ListingsMigrator implements InterfaceMigrator {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
-			WP_CLI::warning( 'Done.' );
+			WP_CLI::warning( 'Done with warnings.' );
 			exit(1);
 		}
 	}
@@ -126,7 +126,7 @@ class ListingsMigrator implements InterfaceMigrator {
 			'post_status'    => [ 'publish', 'future', 'draft', 'pending', 'private', 'inherit' ],
 		] );
 		if ( empty( $posts ) ) {
-			WP_CLI::line( sprintf( 'No Listings found.' ) );
+			WP_CLI::warning( sprintf( 'No Listings found.' ) );
 			return false;
 		}
 
@@ -155,7 +155,7 @@ class ListingsMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Listings file not found %s.', $import_file ) );
 		}
 
-		WP_CLI::line( 'Importing Listings...' );
+		WP_CLI::line( 'Importing Listings from ' . $import_file . ' ...' );
 
 		$this->delete_all_existing_listings();
 		PostsMigrator::get_instance()->import_posts( $import_file );

--- a/src/Migrator/General/MenusMigrator.php
+++ b/src/Migrator/General/MenusMigrator.php
@@ -140,7 +140,7 @@ class MenusMigrator implements InterfaceMigrator {
 		fclose( $open_menu_file );
 
 		// WP_CLI::line( $output );
-		WP_CLI::line( 'Completed menu export: ' . $menu_file );
+		WP_CLI::line( 'Writing to file ' . $menu_file );
 	}
 
 	/**
@@ -290,7 +290,5 @@ class MenusMigrator implements InterfaceMigrator {
 				set_theme_mod( 'nav_menu_locations', $set_menus );
 			}
 		}
-
-		WP_CLI::line( 'Done.' );
 	}
 }

--- a/src/Migrator/General/MenusMigrator.php
+++ b/src/Migrator/General/MenusMigrator.php
@@ -155,7 +155,7 @@ class MenusMigrator implements InterfaceMigrator {
 		$directory = rtrim( $directory, '/' );
 		$menu_file = $directory . '/' . self::MENU_EXPORT_FILE;
 		if ( ! is_file( $menu_file ) ) {
-			WP_CLI::error( sprintf( 'File not found in input-dir %s', $menu_file ) );
+			WP_CLI::error( sprintf( 'Menus file not found in input-dir %s', $menu_file ) );
 		}
 
 		WP_CLI::line( sprintf( 'Importing menus from ' . $menu_file . '...' ) );

--- a/src/Migrator/General/MenusMigrator.php
+++ b/src/Migrator/General/MenusMigrator.php
@@ -155,7 +155,8 @@ class MenusMigrator implements InterfaceMigrator {
 		$directory = rtrim( $directory, '/' );
 		$menu_file = $directory . '/' . self::MENU_EXPORT_FILE;
 		if ( ! is_file( $menu_file ) ) {
-			WP_CLI::error( sprintf( 'Menus file not found in input-dir %s', $menu_file ) );
+			WP_CLI::warning( sprintf( 'Menus file not found in input-dir %s', $menu_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( sprintf( 'Importing menus from ' . $menu_file . '...' ) );

--- a/src/Migrator/General/NewslettersMigrator.php
+++ b/src/Migrator/General/NewslettersMigrator.php
@@ -95,7 +95,7 @@ class NewslettersMigrator implements InterfaceMigrator {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
-			WP_CLI::warning( 'Done.' );
+			WP_CLI::warning( 'Done with warnings.' );
 			exit(1);
 		}
 	}
@@ -142,7 +142,7 @@ class NewslettersMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Newsletters file not found %s.', $import_file ) );
 		}
 
-		WP_CLI::line( 'Importing Newsletters...' );
+		WP_CLI::line( 'Importing Newsletters from ' . $import_file . ' ...' );
 
 		$this->import_newsletterss( $import_file );
 

--- a/src/Migrator/General/NewslettersMigrator.php
+++ b/src/Migrator/General/NewslettersMigrator.php
@@ -92,12 +92,12 @@ class NewslettersMigrator implements InterfaceMigrator {
 
 		$result = $this->export_newsletters( $output_dir, self::NEWSLETTERS_EXPORT_FILE );
 		if ( true === $result ) {
+			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
+			WP_CLI::warning( 'Done.' );
 			exit(1);
 		}
-
-		WP_CLI::success( 'Done.' );
 	}
 
 	/**
@@ -139,7 +139,7 @@ class NewslettersMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::NEWSLETTERS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $import_file ) );
+			WP_CLI::error( sprintf( 'Newsletters file not found %s.', $import_file ) );
 		}
 
 		WP_CLI::line( 'Importing Newsletters...' );

--- a/src/Migrator/General/NewslettersMigrator.php
+++ b/src/Migrator/General/NewslettersMigrator.php
@@ -139,7 +139,8 @@ class NewslettersMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::NEWSLETTERS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Newsletters file not found %s.', $import_file ) );
+			WP_CLI::warning( sprintf( 'Newsletters file not found %s.', $import_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( 'Importing Newsletters from ' . $import_file . ' ...' );

--- a/src/Migrator/General/PostsMigrator.php
+++ b/src/Migrator/General/PostsMigrator.php
@@ -299,8 +299,9 @@ class PostsMigrator implements InterfaceMigrator {
 		}
 
 		// Import Pages from Staging site.
-		WP_CLI::line( 'Importing Pages from the Staging site (uses `wp import` and might take a bit longer) ...' );
-		$this->import_posts( $input_dir . '/' . self::STAGING_PAGES_EXPORT_FILE );
+		$file = $input_dir . '/' . self::STAGING_PAGES_EXPORT_FILE;
+		WP_CLI::line( 'Importing Staging site Pages from  ' . $file . ' (uses `wp import` and might take a bit longer) ...' );
+		$this->import_posts( $file );
 
 		wp_cache_flush();
 

--- a/src/Migrator/General/ReaderRevenueMigrator.php
+++ b/src/Migrator/General/ReaderRevenueMigrator.php
@@ -88,7 +88,7 @@ class ReaderRevenueMigrator implements InterfaceMigrator {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
-			WP_CLI::warning( 'Done.' );
+			WP_CLI::warning( 'Done with warnings.' );
 			exit(1);
 		}
 	}
@@ -110,7 +110,7 @@ class ReaderRevenueMigrator implements InterfaceMigrator {
 			'post_type'      => [ 'product' ],
 		] );
 		if ( empty( $posts ) ) {
-			WP_CLI::line( sprintf( 'No Donation Products found.' ) );
+			WP_CLI::warning( sprintf( 'No Donation Products found.' ) );
 			return false;
 		}
 
@@ -139,7 +139,7 @@ class ReaderRevenueMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Reader Revenue file not found %s.', $import_file ) );
 		}
 
-		WP_CLI::line( 'Importing Reader Revenue Products...' );
+		WP_CLI::line( 'Importing Reader Revenue Products from ' . $import_file . ' ...' );
 
 		$this->delete_all_existing_products();
 		PostsMigrator::get_instance()->import_posts( $import_file );

--- a/src/Migrator/General/ReaderRevenueMigrator.php
+++ b/src/Migrator/General/ReaderRevenueMigrator.php
@@ -136,7 +136,8 @@ class ReaderRevenueMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::READER_REVENUE_PRODUCTS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Reader Revenue file not found %s.', $import_file ) );
+			WP_CLI::warning( sprintf( 'Reader Revenue file not found %s.', $import_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( 'Importing Reader Revenue Products from ' . $import_file . ' ...' );

--- a/src/Migrator/General/ReaderRevenueMigrator.php
+++ b/src/Migrator/General/ReaderRevenueMigrator.php
@@ -85,12 +85,12 @@ class ReaderRevenueMigrator implements InterfaceMigrator {
 
 		$result = $this->export_reader_revenue( $output_dir, self::READER_REVENUE_PRODUCTS_EXPORT_FILE );
 		if ( true === $result ) {
+			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
+			WP_CLI::warning( 'Done.' );
 			exit(1);
 		}
-
-		WP_CLI::success( 'Done.' );
 	}
 
 	/**
@@ -136,7 +136,7 @@ class ReaderRevenueMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::READER_REVENUE_PRODUCTS_EXPORT_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $import_file ) );
+			WP_CLI::error( sprintf( 'Reader Revenue file not found %s.', $import_file ) );
 		}
 
 		WP_CLI::line( 'Importing Reader Revenue Products...' );

--- a/src/Migrator/General/ReusableBlocksMigrator.php
+++ b/src/Migrator/General/ReusableBlocksMigrator.php
@@ -115,7 +115,7 @@ class ReusableBlocksMigrator implements InterfaceMigrator {
 
 		$posts = $this->get_reusable_blocks();
 		if ( empty( $posts ) ) {
-			WP_CLI::line( 'No Reusable Blocks found.' );
+			WP_CLI::warning( 'No Reusable Blocks found.' );
 			exit(1);
 		}
 
@@ -175,7 +175,7 @@ class ReusableBlocksMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Reusable blocks file not found %s.', $import_file ) );
 		}
 
-		WP_CLI::line( 'Importing Reusable Blocks...' );
+		WP_CLI::line( 'Importing Reusable Blocks from ' . $import_file . ' ...' );
 
 		PostsMigrator::get_instance()->import_posts( $import_file );
 

--- a/src/Migrator/General/ReusableBlocksMigrator.php
+++ b/src/Migrator/General/ReusableBlocksMigrator.php
@@ -172,7 +172,7 @@ class ReusableBlocksMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::REUSABLE_BLOCKS_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $import_file ) );
+			WP_CLI::error( sprintf( 'Reusable blocks file not found %s.', $import_file ) );
 		}
 
 		WP_CLI::line( 'Importing Reusable Blocks...' );

--- a/src/Migrator/General/ReusableBlocksMigrator.php
+++ b/src/Migrator/General/ReusableBlocksMigrator.php
@@ -172,7 +172,8 @@ class ReusableBlocksMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::REUSABLE_BLOCKS_FILE;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Reusable blocks file not found %s.', $import_file ) );
+			WP_CLI::warning( sprintf( 'Reusable blocks file not found %s.', $import_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( 'Importing Reusable Blocks from ' . $import_file . ' ...' );

--- a/src/Migrator/General/SettingsMigrator.php
+++ b/src/Migrator/General/SettingsMigrator.php
@@ -131,7 +131,7 @@ class SettingsMigrator implements InterfaceMigrator {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
-			WP_CLI::warning( 'Done.' );
+			WP_CLI::warning( 'Done with warnings.' );
 			exit(1);
 		}
 	}
@@ -165,8 +165,15 @@ class SettingsMigrator implements InterfaceMigrator {
 			$json_data[ 'site_icon_file' ] = get_attached_file( $site_icon_id );
 		}
 
-		// Write JSON file for reference to what was exported.
-		return file_put_contents( $output_dir . '/' . self::SITE_IDENTITY_EXPORTED_OPTIONS_FILENAME, json_encode( $json_data ) );
+		if ( empty( $json_data ) ) {
+			return false;
+		}
+
+		// Write JSON file.
+		$file = $output_dir . '/' . self::SITE_IDENTITY_EXPORTED_OPTIONS_FILENAME;
+		WP_CLI::line( 'Writing to file ' . $file );
+
+		return file_put_contents( $file, json_encode( $json_data ) );
 	}
 
 	/**
@@ -186,7 +193,7 @@ class SettingsMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Site identity settings file not found %s.', $options_import_file ) );
 		}
 
-		WP_CLI::line( 'Importing site identity settings...' );
+		WP_CLI::line( 'Importing site identity settings from ' . $options_import_file . ' ...' );
 
 		// Update current Theme mods.
 		$imported_mods_and_options = json_decode( file_get_contents( $options_import_file ), true );
@@ -273,6 +280,7 @@ class SettingsMigrator implements InterfaceMigrator {
 			exit(1);
 		}
 
+		WP_CLI::line( 'Writing to file ' . $file );
 		WP_CLI::success( 'Done.' );
 		exit(0);
 	}
@@ -294,7 +302,7 @@ class SettingsMigrator implements InterfaceMigrator {
 			WP_CLI::error( sprintf( 'Pages settings file not found %s.', $import_file ) );
 		}
 
-		WP_CLI::line( 'Importing default pages settings...' );
+		WP_CLI::line( 'Importing default pages settings from ' . $import_file . ' ...'  );
 
 		$contents = file_get_contents( $import_file );
 		if ( false === $contents ) {

--- a/src/Migrator/General/SettingsMigrator.php
+++ b/src/Migrator/General/SettingsMigrator.php
@@ -127,7 +127,7 @@ class SettingsMigrator implements InterfaceMigrator {
 		WP_CLI::line( sprintf( 'Exporting site identity settings...' ) );
 
 		$result = $this->export_current_theme_site_identity( $output_dir );
-		if ( true === $result ) {
+		if ( false !== $result ) {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {

--- a/src/Migrator/General/SettingsMigrator.php
+++ b/src/Migrator/General/SettingsMigrator.php
@@ -131,6 +131,7 @@ class SettingsMigrator implements InterfaceMigrator {
 			WP_CLI::success( 'Done.' );
 			exit(0);
 		} else {
+			WP_CLI::warning( 'Done.' );
 			exit(1);
 		}
 	}
@@ -182,7 +183,7 @@ class SettingsMigrator implements InterfaceMigrator {
 
 		$options_import_file = $input_dir . '/' . self::SITE_IDENTITY_EXPORTED_OPTIONS_FILENAME;
 		if ( ! is_file( $options_import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $options_import_file ) );
+			WP_CLI::error( sprintf( 'Site identity settings file not found %s.', $options_import_file ) );
 		}
 
 		WP_CLI::line( 'Importing site identity settings...' );
@@ -290,7 +291,7 @@ class SettingsMigrator implements InterfaceMigrator {
 
 		$import_file = $input_dir . '/' . self::PAGES_SETTINGS_FILENAME;
 		if ( ! is_file( $import_file ) ) {
-			WP_CLI::error( sprintf( 'Can not find %s.', $import_file ) );
+			WP_CLI::error( sprintf( 'Pages settings file not found %s.', $import_file ) );
 		}
 
 		WP_CLI::line( 'Importing default pages settings...' );

--- a/src/Migrator/General/SettingsMigrator.php
+++ b/src/Migrator/General/SettingsMigrator.php
@@ -190,7 +190,8 @@ class SettingsMigrator implements InterfaceMigrator {
 
 		$options_import_file = $input_dir . '/' . self::SITE_IDENTITY_EXPORTED_OPTIONS_FILENAME;
 		if ( ! is_file( $options_import_file ) ) {
-			WP_CLI::error( sprintf( 'Site identity settings file not found %s.', $options_import_file ) );
+			WP_CLI::warning( sprintf( 'Site identity settings file not found %s.', $options_import_file ) );
+			exit(1);
 		}
 
 		WP_CLI::line( 'Importing site identity settings from ' . $options_import_file . ' ...' );


### PR DESCRIPTION
## Changes made in this PR

Cleans up and simplifies the Update Recipe structure and output:
- [renames historic VaultPress wording to Jetpack](https://github.com/Automattic/newspack-custom-content-migrator/commit/8ee75a4a847557e0db7c1c8393067d301a19a5bd)
- [removes unnecessary if-s](https://github.com/Automattic/newspack-custom-content-migrator/commit/0e0153d3232c68902c1e2fdfc6e53618ff33b51e)
- [removes one-liner functions](https://github.com/Automattic/newspack-custom-content-migrator/commit/e5c530998a94a0716ef52378db1674ea81dedb5e)
- [simplifies config variables](https://github.com/Automattic/newspack-custom-content-migrator/commit/500a24c26279accf21b2113fa78bf28af254bdce)
- [`search-replace` is now used if found locally, and downloaded only if not](https://github.com/Automattic/newspack-custom-content-migrator/commit/8ac4ffd702c871f4f4acd6fd5b5161d375d8790d)
- [drops `live_` and `staging_` temp DB tables when done](https://github.com/Automattic/newspack-custom-content-migrator/commit/9dde9aa6107adee941d8326d007bba41cc03a0ff)
- [improves wording in many output messages](https://github.com/Automattic/newspack-custom-content-migrator/commit/9b592ac88c01b701366a167cb13e2a866cd408e4)

## Changes this brings to the Launch content migration

No significant changes in logic were introduced, nor any significant changes in how this script is used. This script is used the exact same way we used it until to now.

## Steps to test
- to emulate the launch content migration, create a test "Launch site" by cloning one of our smallest live sites onto a test domain (similarly as we clone the Staging site to create the Launch site). Call it something in the lines of `nccm-test-launch.newspackstaging.com`
- install the PasswordProtected on this test Launch site (to protect it from unauthorized access or wrong SE indexing)
- create the `/tmp/test_launch` dir
- get the actual Jetpack Rewind archive link from the actual live site you used for cloning base, and download it to the `/tmp/test_launch` dir
- pull this branch, run `composer update` and install this plugin on the test Launch site
- edit the update recipe script, and set the variables at the top as usual:
    - `TABLE_PREFIX`
    - `DB_DEFAULT_CHARSET`
    - `LIVE_JETPACK_ARCHIVE`
    - `LIVE_SQL_DUMP_HOSTNAME_REPLACEMENTS` -- same as ever, for the purposes of this test, key is the live domain and value is this test Launch site's hostname
    - `STAGING_SITE_HOSTNAME` -- this is a new variable, and as the comment above it says it's `site from which this site was cloned. In our normal Launch day content migration process, this would be the hostname of the Staging site, but since to simplify this test we've modified creation of the sites and cloned the test Launch site directly from the live site, just use the live site's domain
    - `TEMP_DIR` can either be left as it is, or better yet changed to `/tmp/test_launch/temp`
- run the update recipe script, confirm all the output was correct, and no unexpected warnings or errors occurred
- delete the test Launch site