### PR TITLE
Feat: NinjaTables exporter

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -47,6 +47,7 @@ PluginSetup::register_migrators( array(
 		Migrator\General\ContentDiffMigrator::class,
 		Migrator\General\WooCommOrdersAndSubscriptionsMigrator::class,
 		Migrator\General\NextgenGalleryMigrator::class,
+		Migrator\General\NinjaTablesMigrator::class,
 
 		// Publisher specific:
 		Migrator\PublisherSpecific\GadisMigrator::class,

--- a/src/MigrationLogic/NinjaTables.php
+++ b/src/MigrationLogic/NinjaTables.php
@@ -70,7 +70,7 @@ class NinjaTables {
 				}
 				array_push( $export_data, $temp );
 			}
-			$this->export_as_csv( $export_data, $file_path );
+			$this->export_as_csv( array_values( $header ), $export_data, $file_path );
 		} elseif ( $format == 'json' ) {
 			$table = get_post( $table_id );
 
@@ -128,12 +128,14 @@ class NinjaTables {
 	/**
 	 * Fill file with CSV data from given array.
 	 *
+	 * @param mixed[] $header Data columns titles.
 	 * @param mixed[] $data Data to save in the file as CSV.
 	 * @param string  $file_path File path where to save the CSV file.
 	 */
-	private function export_as_csv( $data, $file_path ) {
+	private function export_as_csv( $header, $data, $file_path ) {
 		$f = fopen( $file_path, 'w' );
 
+		fputcsv( $f, $header );
 		foreach ( $data as $row ) {
 			fputcsv( $f, $row );
 		}

--- a/src/MigrationLogic/NinjaTables.php
+++ b/src/MigrationLogic/NinjaTables.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace NewspackCustomContentMigrator\MigrationLogic;
+
+use \WP_CLI;
+use \NinjaTablesAdmin;
+use \NinjaTables\Classes\ArrayHelper;
+
+/**
+ * NinjaTables Plugin Migrator Logic.
+ */
+class NinjaTables {
+	/**
+	 * @var null|NinjaTablesAdmin
+	 */
+	public $ninja_tables_admin;
+
+	/**
+	 * NinjaTables constructor.
+	 */
+	public function __construct() {
+		$plugin_path = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : ABSPATH . 'wp-content/plugins';
+
+		$ninja_tables                = $plugin_path . '/ninja-tables/ninja-tables.php';
+		$ninja_tables_class          = $plugin_path . '/ninja-tables/includes/NinjaTableClass.php';
+		$ninja_tables_admin          = $plugin_path . '/ninja-tables/admin/NinjaTablesAdmin.php';
+		$included_ninja_tables       = is_file( $ninja_tables ) && include_once $ninja_tables;
+		$included_ninja_tables_class = is_file( $ninja_tables_class ) && include_once $ninja_tables_class;
+		$included_ninja_tables_admin = is_file( $ninja_tables_admin ) && include_once $ninja_tables_admin;
+
+		if ( false === $included_ninja_tables || false === $included_ninja_tables_class || false === $included_ninja_tables_admin ) {
+			// Ninja Tables is a dependency, and will have to be installed before the public functions/commands can be used.
+			return;
+		}
+
+		$this->ninja_tables_admin = new NinjaTablesAdmin();
+	}
+
+	/**
+	 * Export data function, based on exportData method from the NinjaTables plugin.
+	 *
+	 * @param int    $table_id Table to export ID.
+	 * @param string $file_path File path where to export the data.
+	 * @param string $format Data format to export to. It can be CSV or JSON.
+	 */
+	public function export_data( $table_id, $file_path, $format ) {
+		$table_columns  = \ninja_table_get_table_columns( $table_id, 'admin' );
+		$table_settings = \ninja_table_get_table_settings( $table_id, 'admin' );
+
+		if ( 'csv' === $format ) {
+			$sorting_type  = ArrayHelper::get( $table_settings, 'sorting_type', 'by_created_at' );
+			$table_columns = \ninja_table_get_table_columns( $table_id, 'admin' );
+			$data          = \ninjaTablesGetTablesDataByID( $table_id, $table_columns, $sorting_type, true );
+			$header        = array();
+
+			foreach ( $table_columns as $item ) {
+				$header[ $item['key'] ] = $item['name'];
+			}
+
+			$export_data = array();
+
+			foreach ( $data as $item ) {
+				$temp = array();
+				foreach ( $header as $accessor => $name ) {
+					$value = ArrayHelper::get( $item, $accessor );
+					if ( is_array( $value ) ) {
+						$value = implode( ', ', $value );
+					}
+					$temp[] = $value;
+				}
+				array_push( $export_data, $temp );
+			}
+			$this->export_as_csv( $export_data, $file_path );
+		} elseif ( $format == 'json' ) {
+			$table = get_post( $table_id );
+
+			$data_provider = \ninja_table_get_data_provider( $table_id );
+			$rows          = array();
+			if ( 'default' === $data_provider ) {
+				$raw_rows = \ninja_tables_DbTable()
+					->select( array( 'position', 'owner_id', 'attribute', 'value', 'settings', 'created_at', 'updated_at' ) )
+					->where( 'table_id', $table_id )
+					->get();
+				foreach ( $raw_rows as $row ) {
+					$row->value = json_decode( $row->value, true );
+					$rows[]     = $row;
+				}
+			}
+
+			$matas    = get_post_meta( $table_id );
+			$all_meta = array();
+
+			$excluded_meta_keys = array(
+				'_ninja_table_cache_object',
+				'_ninja_table_cache_html',
+				'_external_cached_data',
+				'_last_external_cached_time',
+				'_last_edited_by',
+				'_last_edited_time',
+				'__ninja_cached_table_html',
+			);
+
+			foreach ( $matas as $meta_key => $meta_value ) {
+				if ( ! in_array( $meta_key, $excluded_meta_keys, true ) ) {
+					if ( isset( $meta_value[0] ) ) {
+						$meta_value            = maybe_unserialize( $meta_value[0] );
+						$all_meta[ $meta_key ] = $meta_value;
+					}
+				}
+			}
+
+			$export_data = array(
+				'post'          => $table,
+				'columns'       => $table_columns,
+				'settings'      => $table_settings,
+				'data_provider' => $data_provider,
+				'metas'         => $all_meta,
+				'rows'          => array(),
+				'original_rows' => $rows,
+			);
+
+			file_put_contents( $file_path, wp_json_encode( $export_data ) );
+		} else {
+			WP_CLI::error( sprintf( 'The %s export format is not supported, please choose either csv or json.', $format ) );
+		}
+	}
+
+	/**
+	 * Fill file with CSV data from given array.
+	 *
+	 * @param mixed[] $data Data to save in the file as CSV.
+	 * @param string  $file_path File path where to save the CSV file.
+	 */
+	private function export_as_csv( $data, $file_path ) {
+		$f = fopen( $file_path, 'w' );
+
+		foreach ( $data as $row ) {
+			fputcsv( $f, $row );
+		}
+
+		fclose( $f );
+	}
+}

--- a/src/Migrator/General/NinjaTablesMigrator.php
+++ b/src/Migrator/General/NinjaTablesMigrator.php
@@ -83,20 +83,14 @@ class NinjaTablesMigrator implements InterfaceMigrator {
 		$reflector = new \ReflectionObject( $this->ninja_tables_logic->ninja_tables_admin );
 		$method    = $reflector->getMethod( 'getAllTablesForMce' );
 		$method->setAccessible( true );
-		$all_tables_raw = $method->invoke( $this->ninja_tables_logic->ninja_tables_admin );
-		$all_tables     = array_filter(
-			array_map(
-				function( $table ) {
-					return $table['value'];
-				},
-				$all_tables_raw
-			)
-		);
+		$all_tables = $method->invoke( $this->ninja_tables_logic->ninja_tables_admin );
 
 		// Export tables.
-		foreach ( $all_tables as $table_id ) {
+		foreach ( $all_tables as $table ) {
+			$table_id             = $table['value'];
+			$table_name           = $table['text'];
 			$_REQUEST['table_id'] = $table_id;
-			$this->ninja_tables_logic->export_data( $table_id, path_join( $assoc_args['output-dir'], "$table_id." . $assoc_args['output-type'] ), $assoc_args['output-type'] );
+			$this->ninja_tables_logic->export_data( $table_id, path_join( $assoc_args['output-dir'], "$table_name." . $assoc_args['output-type'] ), $assoc_args['output-type'] );
 			WP_CLI::line( sprintf( 'Table exported successfully: %d', $table_id ) );
 		}
 		WP_CLI::line( 'Export is done!' );

--- a/src/Migrator/General/NinjaTablesMigrator.php
+++ b/src/Migrator/General/NinjaTablesMigrator.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Migrator\General;
+
+use \WP_CLI;
+use \NewspackCustomContentMigrator\Migrator\InterfaceMigrator;
+use \NewspackCustomContentMigrator\MigrationLogic\NinjaTables as NinjaTablesLogic;
+
+/**
+ * NinjaTables Plugin Migrator.
+ */
+class NinjaTablesMigrator implements InterfaceMigrator {
+	/**
+	 * @var null|InterfaceMigrator Instance.
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var NinjaTablesLogic $ninja_tables_logic
+	 */
+	private $ninja_tables_logic;
+
+	/**
+	 * NinjaTablesMigrator constructor.
+	 */
+	private function __construct() {
+		$this->ninja_tables_logic = new NinjaTablesLogic();
+	}
+
+	/**
+	 * Sets up NinjaTables plugin dependencies.
+	 *
+	 * @return InterfaceMigrator|null
+	 */
+	public static function get_instance() {
+		$class = get_called_class();
+		if ( null === self::$instance ) {
+			self::$instance = new $class();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * See InterfaceMigrator::register_commands.
+	 */
+	public function register_commands() {
+		WP_CLI::add_command(
+			'newspack-content-migrator export-ninja-tables',
+			array( $this, 'cmd_export_ninja_tables' ),
+			array(
+				'shortdesc' => 'Export Ninja tables to a CSV or JSON file.',
+				'synopsis'  => array(
+					array(
+						'type'        => 'assoc',
+						'name'        => 'output-dir',
+						'description' => 'Output directory full path (no ending slash).',
+						'optional'    => false,
+						'repeating'   => false,
+					),
+					array(
+						'type'        => 'assoc',
+						'name'        => 'output-type',
+						'description' => 'Output file type (csv, json). Defaults to CSV.',
+						'optional'    => true,
+						'repeating'   => false,
+						'default'     => 'csv',
+						'options'     => array( 'csv', 'json' ),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callable for `newspack-content-migrator export-ninja-tables`.
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
+	public function cmd_export_ninja_tables( $args, $assoc_args ) {
+		// Get all Ninja tables.
+		$reflector = new \ReflectionObject( $this->ninja_tables_logic->ninja_tables_admin );
+		$method    = $reflector->getMethod( 'getAllTablesForMce' );
+		$method->setAccessible( true );
+		$all_tables_raw = $method->invoke( $this->ninja_tables_logic->ninja_tables_admin );
+		$all_tables     = array_filter(
+			array_map(
+				function( $table ) {
+					return $table['value'];
+				},
+				$all_tables_raw
+			)
+		);
+
+		// Export tables.
+		foreach ( $all_tables as $table_id ) {
+			$_REQUEST['table_id'] = $table_id;
+			$this->ninja_tables_logic->export_data( $table_id, path_join( $assoc_args['output-dir'], "$table_id." . $assoc_args['output-type'] ), $assoc_args['output-type'] );
+			WP_CLI::line( sprintf( 'Table exported successfully: %d', $table_id ) );
+		}
+		WP_CLI::line( 'Export is done!' );
+	}
+}

--- a/src/Migrator/General/NinjaTablesMigrator.php
+++ b/src/Migrator/General/NinjaTablesMigrator.php
@@ -87,11 +87,13 @@ class NinjaTablesMigrator implements InterfaceMigrator {
 
 		// Export tables.
 		foreach ( $all_tables as $table ) {
-			$table_id             = $table['value'];
-			$table_name           = $table['text'];
-			$_REQUEST['table_id'] = $table_id;
-			$this->ninja_tables_logic->export_data( $table_id, path_join( $assoc_args['output-dir'], "$table_name." . $assoc_args['output-type'] ), $assoc_args['output-type'] );
-			WP_CLI::line( sprintf( 'Table exported successfully: %d', $table_id ) );
+			$table_id   = $table['value'];
+			$table_name = $table['text'];
+			if ( $table_id ) {
+				$_REQUEST['table_id'] = $table_id;
+				$this->ninja_tables_logic->export_data( $table_id, path_join( $assoc_args['output-dir'], "$table_name." . $assoc_args['output-type'] ), $assoc_args['output-type'] );
+				WP_CLI::line( sprintf( 'Table exported successfully: %d', $table_id ) );
+			}
 		}
 		WP_CLI::line( 'Export is done!' );
 	}

--- a/src/Migrator/General/NinjaTablesMigrator.php
+++ b/src/Migrator/General/NinjaTablesMigrator.php
@@ -79,6 +79,9 @@ class NinjaTablesMigrator implements InterfaceMigrator {
 	 * @param array $assoc_args
 	 */
 	public function cmd_export_ninja_tables( $args, $assoc_args ) {
+		if ( is_null( $this->ninja_tables_logic->ninja_tables_admin ) ) {
+			WP_CLI::error( 'Ninja Tables plugin is a dependency, and will have to be installed before this command can be used.' );
+		}
 		// Get all Ninja tables.
 		$reflector = new \ReflectionObject( $this->ninja_tables_logic->ninja_tables_admin );
 		$method    = $reflector->getMethod( 'getAllTablesForMce' );


### PR DESCRIPTION
This PR proposes a bulk exporter for the tables created with NinjaTables.

A first attempt to do this was by doing it manually (querying the tables ...) but I switched to use the same way we use with other migratory which is using the plugin already made classes/methods. So in order to work, the command needs the NinjaTables plugin to be installed.

As of now, there is only one command that does the bulk import if needed in the future we can add a parameter or a second command to export a specific table.

The command export to either CSV or JSON files (default to CSV). Below are a few examples to use the command:

```bash
# Export all tables to a given folder (/tmp) as CSV files.
wp newspack-content-migrator export-ninja-tables --output-dir=/tmp
# Export all tables to a given folder (/tmp) as JSON files.
wp newspack-content-migrator export-ninja-tables --output-dir=/tmp --output-type=json
```

@iuravic @eddiesshop  I'll need a code review since it introduces a migration logic class too (No rush :)).


