### PR TITLE
Feat: TablePress importer

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -47,6 +47,7 @@ PluginSetup::register_migrators( array(
 		Migrator\General\ContentDiffMigrator::class,
 		Migrator\General\WooCommOrdersAndSubscriptionsMigrator::class,
 		Migrator\General\NextgenGalleryMigrator::class,
+		Migrator\General\TablePressMigrator::class,
 
 		// Publisher specific:
 		Migrator\PublisherSpecific\GadisMigrator::class,

--- a/src/MigrationLogic/TablePress.php
+++ b/src/MigrationLogic/TablePress.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace NewspackCustomContentMigrator\MigrationLogic;
+
+use \TablePress as TablePress_Plugin;
+use \TablePress_Import;
+use \TablePress_Admin_Controller;
+
+/**
+ * TablePress Plugin Migrator Logic.
+ */
+class TablePress {
+	/**
+	 * @var null|TablePress_Import
+	 */
+	public $tablepress_import;
+
+	/**
+	 * @var null|TablePress_Admin_Controller
+	 */
+	public $tablepress_controller_admin;
+
+	/**
+	 * TablePress constructor.
+	 */
+	public function __construct() {
+		$plugin_path = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : ABSPATH . 'wp-content/plugins';
+
+		$tablepress                           = $plugin_path . '/tablepress/tablepress.php';
+		$tablepress_import                    = $plugin_path . '/tablepress/classes/class-import.php';
+		$tablepress_controller                = $plugin_path . '/tablepress/classes/class-controller.php';
+		$tablepress_controller_admin          = $plugin_path . '/tablepress/controllers/controller-admin.php';
+		$included_tablepress                  = is_file( $tablepress ) && include_once $tablepress;
+		$included_tablepress_import           = is_file( $tablepress_import ) && include_once $tablepress_import;
+		$included_tablepress_controller       = is_file( $tablepress_controller ) && include_once $tablepress_controller;
+		$included_tablepress_controller_admin = is_file( $tablepress_controller_admin ) && include_once $tablepress_controller_admin;
+
+		if ( false === $included_tablepress || false === $included_tablepress_import || false === $included_tablepress_controller_admin || false === $included_tablepress_controller ) {
+			// TablePress is a dependency, and will have to be installed before the public functions/commands can be used.
+			return;
+		}
+
+		TablePress_Plugin::run();
+		$this->tablepress_import           = new TablePress_Import();
+		$this->tablepress_controller_admin = new TablePress_Admin_Controller();
+	}
+
+	/**
+	 * Import a table.
+	 *
+	 * @param string $format Import format.
+	 * @param string $data   Data to import.
+	 * @return array|false Table array on success, false on error.
+	 */
+	public function import_table( $format, $data, $filename, $description ) {
+		$reflector = new \ReflectionObject( $this->tablepress_controller_admin );
+		$importer  = $reflector->getProperty( 'importer' );
+		$importer->setAccessible( true );
+		$method = $reflector->getMethod( '_import_tablepress_table' );
+		$method->setAccessible( true );
+
+		$name = basename( $filename, ".$format" );
+
+		$importer->setValue( $this->tablepress_controller_admin, $this->tablepress_import );
+		return $method->invoke( $this->tablepress_controller_admin, $format, $data, $name, $description, false, 'add' );
+	}
+}

--- a/src/Migrator/General/TablePressMigrator.php
+++ b/src/Migrator/General/TablePressMigrator.php
@@ -79,8 +79,13 @@ class TablePressMigrator implements InterfaceMigrator {
 	 * @param array $assoc_args
 	 */
 	public function cmd_import_table_press( $args, $assoc_args ) {
+		if ( is_null( $this->table_press_logic->tablepress_import ) ) {
+			WP_CLI::error( 'TablePress plugin is a dependency, and will have to be installed before this command can be used.' );
+		}
+
 		$table_files  = array_filter( glob( $assoc_args['input-dir'] . '/*.' . $assoc_args['input-type'] ), 'is_file' );
 		$total_tables = count( $table_files );
+
 		foreach ( $table_files as $key_table_file => $table_file ) {
 			WP_CLI::line( sprintf( 'Importing table %d/%d.', $key_table_file + 1, $total_tables ) );
 

--- a/src/Migrator/General/TablePressMigrator.php
+++ b/src/Migrator/General/TablePressMigrator.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Migrator\General;
+
+use \WP_CLI;
+use \NewspackCustomContentMigrator\Migrator\InterfaceMigrator;
+use \NewspackCustomContentMigrator\MigrationLogic\TablePress as TablePressLogic;
+
+/**
+ * TablePress Plugin Migrator.
+ */
+class TablePressMigrator implements InterfaceMigrator {
+	/**
+	 * @var null|InterfaceMigrator Instance.
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var TablePressLogic $table_press_logic
+	 */
+	private $table_press_logic;
+
+	/**
+	 * TablePressMigrator constructor.
+	 */
+	private function __construct() {
+		$this->table_press_logic = new TablePressLogic();
+	}
+
+	/**
+	 * Sets up TablePress plugin dependencies.
+	 *
+	 * @return InterfaceMigrator|null
+	 */
+	public static function get_instance() {
+		$class = get_called_class();
+		if ( null === self::$instance ) {
+			self::$instance = new $class();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * See InterfaceMigrator::register_commands.
+	 */
+	public function register_commands() {
+		WP_CLI::add_command(
+			'newspack-content-migrator import-table-press-tables',
+			array( $this, 'cmd_import_table_press' ),
+			array(
+				'shortdesc' => 'Import CSV or JSON files to TablePress plugin.',
+				'synopsis'  => array(
+					array(
+						'type'        => 'assoc',
+						'name'        => 'input-dir',
+						'description' => 'Input directory full path (no ending slash).',
+						'optional'    => false,
+						'repeating'   => false,
+					),
+					array(
+						'type'        => 'assoc',
+						'name'        => 'input-type',
+						'description' => 'Input file type (csv, json). Defaults to CSV.',
+						'optional'    => true,
+						'repeating'   => false,
+						'default'     => 'csv',
+						'options'     => array( 'csv', 'json' ),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Callable for `newspack-content-migrator import-table-press-tables`.
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
+	public function cmd_import_table_press( $args, $assoc_args ) {
+		$table_files  = array_filter( glob( $assoc_args['input-dir'] . '/*.' . $assoc_args['input-type'] ), 'is_file' );
+		$total_tables = count( $table_files );
+		foreach ( $table_files as $key_table_file => $table_file ) {
+			WP_CLI::line( sprintf( 'Importing table %d/%d.', $key_table_file + 1, $total_tables ) );
+
+			$data     = file_get_contents( $table_file ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$table_id = $this->table_press_logic->import_table( $assoc_args['input-type'], $data, $table_file, 'Imported table.' );
+			if ( \is_wp_error( $table_id ) ) {
+				WP_CLI::warning( sprintf( 'An error occured while importing the table %s', $table_file ) );
+			}
+		}
+
+		WP_CLI::line( 'Import is done!' );
+	}
+}


### PR DESCRIPTION
This PR introduces a bulk tables importer to TablePress. It accepts CSV and JSON files from a given folder.

It uses the filename as the table name and the first row of data as the table header (same as the GUI importer of TablePress).

Since the import command uses the internal classes/methods of the plugin TablePress, the plugin should be installed before using it.

Below some examples to use the command line:

```bash
# Import bulk CSV tables from /tmp folder.
wp newspack-content-migrator import-table-press-tables --input-dir=/tmp
# Import bulk JSON tables from /tmp folder.
wp newspack-content-migrator import-table-press-tables --input-dir=/tmp --input-type=json
```

The code introduces a new migrator logic class so it needs a review 🙇 