### PR TITLE
fix(Ithaca Voice): fix the galleries migrator loop to go over all the posts

### DIFF
--- a/src/Migrator/PublisherSpecific/IthacaVoiceMigrator.php
+++ b/src/Migrator/PublisherSpecific/IthacaVoiceMigrator.php
@@ -89,7 +89,6 @@ class IthacaVoiceMigrator implements InterfaceMigrator {
 			array(
 				'post_type'   => 'post',
 				'post_status' => array( 'publish' ),
-				'post__in'    => array( 88405 ),
 			),
 			function( $post ) use ( $wpdb ) {
 				if ( strpos( strtolower( $post->post_content ), strtolower( '[Best_Wordpress_Gallery' ) ) !== false ) {


### PR DESCRIPTION
@iuravic @eddiesshop, a quick fix for the posts loop for Ithaca Voice galleries migrator, I forgot the `post__in` argument that was there to test the migrator, I'll skip the PR review for this one.