### PR TITLE
Feat/woo subscriptions payment method switcher

### DIFF
--- a/src/Migrator/General/WooCommOrdersAndSubscriptionsMigrator.php
+++ b/src/Migrator/General/WooCommOrdersAndSubscriptionsMigrator.php
@@ -11,7 +11,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 
 	const EXCEPTION_CODE_SKIP_IMPORTING = 700;
 
-	const WOOCOMM_ORDER_CPT = 'shop_order';
+	const WOOCOMM_ORDER_CPT        = 'shop_order';
 	const WOOCOMM_SUBSCRIPTION_CPT = 'shop_subscription';
 
 	/**
@@ -52,14 +52,14 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 					[
 						'type'        => 'assoc',
 						'name'        => 'source-table-prefix',
-						'description' => "Source DB tables prefix.",
+						'description' => 'Source DB tables prefix.',
 						'optional'    => false,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'destination-table-prefix',
-						'description' => "Destination DB tables prefix.",
+						'description' => 'Destination DB tables prefix.',
 						'optional'    => false,
 						'repeating'   => false,
 					],
@@ -89,13 +89,13 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 	 * @param $assoc_args
 	 */
 	public function cmd_wc_order_migrate( $args, $assoc_args ) {
-		$table_prefix_source = $assoc_args[ 'source-table-prefix' ] ?? null;
-		$table_prefix_destination = $assoc_args[ 'destination-table-prefix' ] ?? null;
-		$source_order_ids = $assoc_args[ 'source-order-ids-csv' ] ?? null;
+		$table_prefix_source      = $assoc_args['source-table-prefix'] ?? null;
+		$table_prefix_destination = $assoc_args['destination-table-prefix'] ?? null;
+		$source_order_ids         = $assoc_args['source-order-ids-csv'] ?? null;
 		if ( $source_order_ids ) {
 			$source_order_ids = explode( ',', $source_order_ids );
 		}
-		$source_subscription_ids = $assoc_args[ 'source-subscription-ids-csv' ] ?? null;
+		$source_subscription_ids = $assoc_args['source-subscription-ids-csv'] ?? null;
 		if ( $source_subscription_ids ) {
 			$source_subscription_ids = explode( ',', $source_subscription_ids );
 		}
@@ -103,10 +103,10 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			WP_CLI::error( 'Must provide either Order IDs and/or Subscription IDs.' );
 		}
 
-		WP_CLI::warning( "Please make sure Order Products have the same IDs, or improve this script to import Products, too." );
+		WP_CLI::warning( 'Please make sure Order Products have the same IDs, or improve this script to import Products, too.' );
 
 		foreach ( $source_order_ids as $key_source_order_ids => $source_order_id ) {
-			$msg = sprintf( '(%d/%d) Getting order ID %d', $key_source_order_ids + 1, count($source_order_ids), $source_order_id );
+			$msg = sprintf( '(%d/%d) Getting order ID %d', $key_source_order_ids + 1, count( $source_order_ids ), $source_order_id );
 			WP_CLI::success( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 
@@ -157,12 +157,12 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 		}
 
 		// Sanitize table prefixes.
-		$table_prefix_source = sanitize_key( $table_prefix_source );
+		$table_prefix_source      = sanitize_key( $table_prefix_source );
 		$table_prefix_destination = sanitize_key( $table_prefix_destination );
 
 		// Is this an Order or a Subscription.
-		$cpt = ! is_null( $source_order_id ) ? self::WOOCOMM_ORDER_CPT : self::WOOCOMM_SUBSCRIPTION_CPT;
-		$object_name = self::WOOCOMM_ORDER_CPT == $cpt ? 'Order' : 'Subscription';
+		$cpt              = ! is_null( $source_order_id ) ? self::WOOCOMM_ORDER_CPT : self::WOOCOMM_SUBSCRIPTION_CPT;
+		$object_name      = self::WOOCOMM_ORDER_CPT == $cpt ? 'Order' : 'Subscription';
 		$source_object_id = ! is_null( $source_order_id ) ? $source_order_id : $source_subscription_id;
 
 		$order_row = $wpdb->get_row(
@@ -177,7 +177,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			ARRAY_A
 		);
 		if ( empty( $order_row ) ) {
-			$msg = sprintf( "ERROR: could not find %s ID %d. Skipping.", $object_name, $source_object_id );
+			$msg = sprintf( 'ERROR: could not find %s ID %d. Skipping.', $object_name, $source_object_id );
 			WP_CLI::warning( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 			throw new \RuntimeException( $msg, self::EXCEPTION_CODE_SKIP_IMPORTING );
@@ -196,7 +196,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			ARRAY_A
 		);
 		if ( empty( $order_meta_rows ) ) {
-			$msg = sprintf( "ERROR: could not find meta for %s ID %d. Skipping.", $object_name, $source_object_id );
+			$msg = sprintf( 'ERROR: could not find meta for %s ID %d. Skipping.', $object_name, $source_object_id );
 			WP_CLI::warning( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 			throw new \RuntimeException( $msg, self::EXCEPTION_CODE_SKIP_IMPORTING );
@@ -215,7 +215,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			ARRAY_A
 		);
 		if ( empty( $order_comments_rows ) ) {
-			$msg = sprintf( "No %s comments found", $object_name );
+			$msg = sprintf( 'No %s comments found', $object_name );
 			WP_CLI::success( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 		} else {
@@ -233,7 +233,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			ARRAY_A
 		);
 		if ( empty( $order_stats_rows ) ) {
-			$msg = sprintf( "WARNING: could not find %s stats", $object_name );
+			$msg = sprintf( 'WARNING: could not find %s stats', $object_name );
 			WP_CLI::success( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 		} else {
@@ -251,7 +251,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			ARRAY_A
 		);
 		if ( empty( $order_items_rows ) ) {
-			$msg = sprintf( "WARNING: could not find %s items.", $object_name );
+			$msg = sprintf( 'WARNING: could not find %s items.', $object_name );
 			WP_CLI::success( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 
@@ -265,15 +265,14 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			foreach ( $order_items_rows as $order_items_row ) {
 
 				// Key is order_item_id, and values are its meta.
-				$order_items_metas[ $order_items_row[ 'order_item_id' ] ] = $wpdb->get_results(
+				$order_items_metas[ $order_items_row['order_item_id'] ] = $wpdb->get_results(
 					$wpdb->prepare(
 						"select * from {$table_prefix_source}woocommerce_order_itemmeta
 							where order_item_id = %d;",
-						$order_items_row[ 'order_item_id' ]
+						$order_items_row['order_item_id']
 					),
 					ARRAY_A
 				);
-
 			}
 			$msg = sprintf( 'Found %s items meta', $object_name );
 			WP_CLI::success( $msg );
@@ -289,7 +288,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			ARRAY_A
 		);
 		if ( empty( $order_product_lookup_rows ) ) {
-			$msg = sprintf( "WARNING: could not find %s product lookup records.", $object_name );
+			$msg = sprintf( 'WARNING: could not find %s product lookup records.', $object_name );
 			WP_CLI::success( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 		} else {
@@ -298,7 +297,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			$this->log( self::GENERAL_LOG, $msg );
 		}
 
-		$order_user = $wpdb->get_row(
+		$order_user                = $wpdb->get_row(
 			$wpdb->prepare(
 				"select wu.* from {$table_prefix_source}users wu
 					join {$table_prefix_source}postmeta wpm on wpm.meta_value = wu.ID
@@ -308,14 +307,14 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			),
 			ARRAY_A
 		);
-		$order_user_meta = [];
+		$order_user_meta           = [];
 		$order_customer_lookup_row = [];
 		if ( empty( $order_user ) ) {
-			$msg = sprintf( "WARNING: could not find WP User for %s ID %d.", $object_name, $source_object_id );
+			$msg = sprintf( 'WARNING: could not find WP User for %s ID %d.', $object_name, $source_object_id );
 			WP_CLI::success( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 		} else {
-			$msg = sprintf( 'Found %s WP User ID %s', $object_name, $order_user[ 'ID' ] );
+			$msg = sprintf( 'Found %s WP User ID %s', $object_name, $order_user['ID'] );
 			WP_CLI::success( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 
@@ -323,12 +322,12 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 				$wpdb->prepare(
 					"select wum.* from {$table_prefix_source}usermeta wum
 					where wum.user_id = %d;",
-					$order_user[ 'ID' ]
+					$order_user['ID']
 				),
 				ARRAY_A
 			);
 			if ( empty( $order_user_meta ) ) {
-				$msg = sprintf( "WARNING: could not find WP User Meta for %s ID %d.", $object_name, $source_object_id );
+				$msg = sprintf( 'WARNING: could not find WP User Meta for %s ID %d.', $object_name, $source_object_id );
 				WP_CLI::success( $msg );
 				$this->log( self::GENERAL_LOG, $msg );
 			} else {
@@ -341,20 +340,19 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 				$wpdb->prepare(
 					"select wccl.* from {$table_prefix_source}wc_customer_lookup wccl
 					where wccl.user_id = %d;",
-					$order_user[ 'ID' ]
+					$order_user['ID']
 				),
 				ARRAY_A
 			);
 			if ( empty( $order_customer_lookup_row ) ) {
-				$msg = sprintf( "WARNING: could not find customer lookup records for %s ID %d. Skipping.", $object_name, $source_object_id );
+				$msg = sprintf( 'WARNING: could not find customer lookup records for %s ID %d. Skipping.', $object_name, $source_object_id );
 				WP_CLI::success( $msg );
 				$this->log( self::GENERAL_LOG, $msg );
 			}
-			$msg = sprintf( 'Found %s WC Customer lookup ID %s', $object_name, $order_customer_lookup_row[ 'customer_id' ] );
+			$msg = sprintf( 'Found %s WC Customer lookup ID %s', $object_name, $order_customer_lookup_row['customer_id'] );
 			WP_CLI::success( $msg );
 			$this->log( self::GENERAL_LOG, $msg );
 		}
-
 
 		// Import WP User.
 		if ( ! empty( $order_user ) ) {
@@ -362,14 +360,14 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 				$wpdb->prepare(
 					"select wu.* from {$table_prefix_destination}users wu
 					where wu.user_login = %s;",
-					$order_user[ 'user_login' ]
+					$order_user['user_login']
 				),
 				ARRAY_A
 			);
 			$user_already_exists = ! empty( $order_existing_user );
 			if ( $user_already_exists ) {
-				$user_id = $order_existing_user[ 'ID' ];
-				$msg = sprintf( 'Importing WP User, existing user found, ID %d', $user_id );
+				$user_id = $order_existing_user['ID'];
+				$msg     = sprintf( 'Importing WP User, existing user found, ID %d', $user_id );
 				$this->log( self::GENERAL_LOG, $msg );
 				WP_CLI::success( $msg );
 			} else {
@@ -377,24 +375,24 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 					"insert into {$table_prefix_destination}users
 					(user_login,user_pass,user_nicename,user_email,user_url,user_registered,user_activation_key,user_status,display_name)
 					values (%s,%s,%s,%s,%s,%s,%s,%s,%s); ",
-					$order_user[ 'user_login' ],
-					$order_user[ 'user_pass' ],
-					$order_user[ 'user_nicename' ],
-					$order_user[ 'user_email' ],
-					$order_user[ 'user_url' ],
-					$order_user[ 'user_registered' ],
-					$order_user[ 'user_activation_key' ],
-					$order_user[ 'user_status' ],
-					$order_user[ 'display_name' ],
+					$order_user['user_login'],
+					$order_user['user_pass'],
+					$order_user['user_nicename'],
+					$order_user['user_email'],
+					$order_user['user_url'],
+					$order_user['user_registered'],
+					$order_user['user_activation_key'],
+					$order_user['user_status'],
+					$order_user['display_name'],
 				);
-				$res = $wpdb->query( $query );
+				$res   = $wpdb->query( $query );
 				if ( 1 != $res ) {
-					$msg = sprintf( 'ERROR: WP User insert error, user_login %s', $order_user[ 'user_login' ] );
+					$msg = sprintf( 'ERROR: WP User insert error, user_login %s', $order_user['user_login'] );
 					$this->log( self::GENERAL_LOG, $msg );
 					WP_CLI::warning( $msg );
 				}
 				$user_id = $wpdb->insert_id;
-				$msg = sprintf( 'Imported WP User ID %d', $user_id );
+				$msg     = sprintf( 'Imported WP User ID %d', $user_id );
 				$this->log( self::GENERAL_LOG, $msg );
 				WP_CLI::success( $msg );
 
@@ -404,12 +402,12 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 						(user_id,meta_key,meta_value)
 						values (%s,%s,%s); ",
 						$user_id,
-						$order_user_meta_row[ 'meta_key' ],
-						$order_user_meta_row[ 'meta_value' ],
+						$order_user_meta_row['meta_key'],
+						$order_user_meta_row['meta_value'],
 					);
-					$res = $wpdb->query( $query );
+					$res   = $wpdb->query( $query );
 					if ( 1 != $res ) {
-						$msg = sprintf( 'ERROR: WP User meta insert error, source meta ID %d', $order_user_meta_row[ 'umeta_id' ] );
+						$msg = sprintf( 'ERROR: WP User meta insert error, source meta ID %d', $order_user_meta_row['umeta_id'] );
 						$this->log( self::GENERAL_LOG, $msg );
 						WP_CLI::warning( $msg );
 					}
@@ -434,27 +432,27 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			),
 			ARRAY_A
 		);
-		$customer_lookup_already_exists = ! empty( $customer_lookup_existing_record );
+		$customer_lookup_already_exists  = ! empty( $customer_lookup_existing_record );
 		if ( ! $customer_lookup_already_exists ) {
 			$query = $wpdb->prepare(
 				"insert into {$table_prefix_destination}wc_customer_lookup
 					(user_id,username,first_name,last_name,email,date_last_active,date_registered,country,postcode,city,state)
 					values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s); ",
 				$user_id,
-				$order_customer_lookup_row[ 'username' ],
-				$order_customer_lookup_row[ 'first_name' ],
-				$order_customer_lookup_row[ 'last_name' ],
-				$order_customer_lookup_row[ 'email' ],
-				$order_customer_lookup_row[ 'date_last_active' ],
-				$order_customer_lookup_row[ 'date_registered' ],
-				$order_customer_lookup_row[ 'country' ],
-				$order_customer_lookup_row[ 'postcode' ],
-				$order_customer_lookup_row[ 'city' ],
-				$order_customer_lookup_row[ 'state' ],
+				$order_customer_lookup_row['username'],
+				$order_customer_lookup_row['first_name'],
+				$order_customer_lookup_row['last_name'],
+				$order_customer_lookup_row['email'],
+				$order_customer_lookup_row['date_last_active'],
+				$order_customer_lookup_row['date_registered'],
+				$order_customer_lookup_row['country'],
+				$order_customer_lookup_row['postcode'],
+				$order_customer_lookup_row['city'],
+				$order_customer_lookup_row['state'],
 			);
-			$res = $wpdb->query( $query );
+			$res   = $wpdb->query( $query );
 			if ( 1 != $res ) {
-				$msg = sprintf( 'ERROR: customer lookup insert error, source customer_id %d', $order_customer_lookup_row[ 'customer_id' ] );
+				$msg = sprintf( 'ERROR: customer lookup insert error, source customer_id %d', $order_customer_lookup_row['customer_id'] );
 				$this->log( self::GENERAL_LOG, $msg );
 				WP_CLI::warning( $msg );
 			}
@@ -464,7 +462,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 			$this->log( self::GENERAL_LOG, $msg );
 			WP_CLI::success( $msg );
 		} else {
-			$customer_id = $customer_lookup_existing_record[ 'customer_id' ];
+			$customer_id = $customer_lookup_existing_record['customer_id'];
 
 			$msg = sprintf( 'Importing Customer lookup, existing record found, customer_id %d', $customer_id );
 			$this->log( self::GENERAL_LOG, $msg );
@@ -472,34 +470,34 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 		}
 
 		// Import Order or Subscription.
-		$query = $wpdb->prepare(
+		$query    = $wpdb->prepare(
 			"insert into {$table_prefix_destination}posts
 				(post_author,post_date,post_date_gmt,post_content,post_title,post_excerpt,post_status,comment_status,ping_status,post_password,post_name,to_ping,pinged,post_modified,post_modified_gmt,post_content_filtered,post_parent,guid,menu_order,post_type,post_mime_type,comment_count)
 				values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s); ",
-			$order_row[ 'post_author' ],
-			$order_row[ 'post_date' ],
-			$order_row[ 'post_date_gmt' ],
-			$order_row[ 'post_content' ],
-			$order_row[ 'post_title' ],
-			$order_row[ 'post_excerpt' ],
-			$order_row[ 'post_status' ],
-			$order_row[ 'comment_status' ],
-			$order_row[ 'ping_status' ],
-			$order_row[ 'post_password' ],
-			$order_row[ 'post_name' ],
-			$order_row[ 'to_ping' ],
-			$order_row[ 'pinged' ],
-			$order_row[ 'post_modified' ],
-			$order_row[ 'post_modified_gmt' ],
-			$order_row[ 'post_content_filtered' ],
-			$order_row[ 'post_parent' ],
-			$order_row[ 'guid' ],
-			$order_row[ 'menu_order' ],
-			$order_row[ 'post_type' ],
-			$order_row[ 'post_mime_type' ],
-			$order_row[ 'comment_count' ],
+			$order_row['post_author'],
+			$order_row['post_date'],
+			$order_row['post_date_gmt'],
+			$order_row['post_content'],
+			$order_row['post_title'],
+			$order_row['post_excerpt'],
+			$order_row['post_status'],
+			$order_row['comment_status'],
+			$order_row['ping_status'],
+			$order_row['post_password'],
+			$order_row['post_name'],
+			$order_row['to_ping'],
+			$order_row['pinged'],
+			$order_row['post_modified'],
+			$order_row['post_modified_gmt'],
+			$order_row['post_content_filtered'],
+			$order_row['post_parent'],
+			$order_row['guid'],
+			$order_row['menu_order'],
+			$order_row['post_type'],
+			$order_row['post_mime_type'],
+			$order_row['comment_count'],
 		);
-		$res = $wpdb->query( $query );
+		$res      = $wpdb->query( $query );
 		$order_id = $wpdb->insert_id;
 		if ( 1 != $res ) {
 			$msg = sprintf( 'ERROR: %s insert error, source ID %d', $object_name, $source_object_id );
@@ -513,8 +511,8 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 
 		// Import Meta.
 		foreach ( $order_meta_rows as $order_meta_row ) {
-			$meta_value = $order_meta_row[ 'meta_value' ];
-			if ( '_customer_user' == $order_meta_row[ 'meta_key' ] ) {
+			$meta_value = $order_meta_row['meta_value'];
+			if ( '_customer_user' == $order_meta_row['meta_key'] ) {
 				$meta_value = $user_id;
 			}
 			$query = $wpdb->prepare(
@@ -522,12 +520,12 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 					(post_id,meta_key,meta_value)
 					values (%s,%s,%s); ",
 				$order_id,
-				$order_meta_row[ 'meta_key' ],
+				$order_meta_row['meta_key'],
 				$meta_value
 			);
-			$res = $wpdb->query( $query );
+			$res   = $wpdb->query( $query );
 			if ( 1 != $res ) {
-				$msg = sprintf( 'ERROR: %s post meta insert error, source meta ID %d', $object_name, $order_meta_row[ 'meta_id' ] );
+				$msg = sprintf( 'ERROR: %s post meta insert error, source meta ID %d', $object_name, $order_meta_row['meta_id'] );
 				$this->log( self::GENERAL_LOG, $msg );
 				WP_CLI::warning( $msg );
 			}
@@ -544,23 +542,23 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 					(comment_post_ID,comment_author,comment_author_email,comment_author_url,comment_author_IP,comment_date,comment_date_gmt,comment_content,comment_karma,comment_approved,comment_agent,comment_type,comment_parent,user_id)
 					values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s); ",
 				$order_id,
-				$order_comments_row[ 'comment_author' ],
-				$order_comments_row[ 'comment_author_email' ],
-				$order_comments_row[ 'comment_author_url' ],
-				$order_comments_row[ 'comment_author_IP' ],
-				$order_comments_row[ 'comment_date' ],
-				$order_comments_row[ 'comment_date_gmt' ],
-				$order_comments_row[ 'comment_content' ],
-				$order_comments_row[ 'comment_karma' ],
-				$order_comments_row[ 'comment_approved' ],
-				$order_comments_row[ 'comment_agent' ],
-				$order_comments_row[ 'comment_type' ],
-				$order_comments_row[ 'comment_parent' ],
-				$order_comments_row[ 'user_id' ],
+				$order_comments_row['comment_author'],
+				$order_comments_row['comment_author_email'],
+				$order_comments_row['comment_author_url'],
+				$order_comments_row['comment_author_IP'],
+				$order_comments_row['comment_date'],
+				$order_comments_row['comment_date_gmt'],
+				$order_comments_row['comment_content'],
+				$order_comments_row['comment_karma'],
+				$order_comments_row['comment_approved'],
+				$order_comments_row['comment_agent'],
+				$order_comments_row['comment_type'],
+				$order_comments_row['comment_parent'],
+				$order_comments_row['user_id'],
 			);
-			$res = $wpdb->query( $query );
+			$res   = $wpdb->query( $query );
 			if ( 1 != $res ) {
-				$msg = sprintf( 'ERROR: %s comment insert error, source comment_ID %d', $object_name, $order_comments_row[ 'comment_ID' ] );
+				$msg = sprintf( 'ERROR: %s comment insert error, source comment_ID %d', $object_name, $order_comments_row['comment_ID'] );
 				$this->log( self::GENERAL_LOG, $msg );
 				WP_CLI::warning( $msg );
 			}
@@ -577,19 +575,19 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
     				(order_id,parent_id,date_created,date_created_gmt,num_items_sold,total_sales,tax_total,shipping_total,net_total,returning_customer,status,customer_id)
 					values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s); ",
 				$order_id,
-				$order_stats_row[ 'parent_id' ],
-				$order_stats_row[ 'date_created' ],
-				$order_stats_row[ 'date_created_gmt' ],
-				$order_stats_row[ 'num_items_sold' ],
-				$order_stats_row[ 'total_sales' ],
-				$order_stats_row[ 'tax_total' ],
-				$order_stats_row[ 'shipping_total' ],
-				$order_stats_row[ 'net_total' ],
-				$order_stats_row[ 'returning_customer' ],
-				$order_stats_row[ 'status' ],
+				$order_stats_row['parent_id'],
+				$order_stats_row['date_created'],
+				$order_stats_row['date_created_gmt'],
+				$order_stats_row['num_items_sold'],
+				$order_stats_row['total_sales'],
+				$order_stats_row['tax_total'],
+				$order_stats_row['shipping_total'],
+				$order_stats_row['net_total'],
+				$order_stats_row['returning_customer'],
+				$order_stats_row['status'],
 				$customer_id,
 			);
-			$res = $wpdb->query( $query );
+			$res   = $wpdb->query( $query );
 			if ( 1 != $res ) {
 				$msg = sprintf( 'ERROR: %s stats insert error, source order_id ID %d', $object_name, $order_id );
 				$this->log( self::GENERAL_LOG, $msg );
@@ -607,13 +605,13 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 				"insert into {$table_prefix_destination}woocommerce_order_items
 					(order_item_name,order_item_type,order_id)
 					values (%s,%s,%s); ",
-				$order_items_row[ 'order_item_name' ],
-				$order_items_row[ 'order_item_type' ],
+				$order_items_row['order_item_name'],
+				$order_items_row['order_item_type'],
 				$order_id,
 			);
-			$res = $wpdb->query( $query );
+			$res   = $wpdb->query( $query );
 			if ( 1 != $res ) {
-				$msg = sprintf( 'ERROR: %s item insert error, source order_item_id ID %d', $object_name, $order_items_row[ 'order_item_id' ] );
+				$msg = sprintf( 'ERROR: %s item insert error, source order_item_id ID %d', $object_name, $order_items_row['order_item_id'] );
 				$this->log( self::GENERAL_LOG, $msg );
 				WP_CLI::warning( $msg );
 				continue;
@@ -621,18 +619,18 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 				$order_item_id = $wpdb->insert_id;
 
 				// Insert order item meta.
-				$source_order_item_id = $order_items_row[ 'order_item_id' ];
-				if ( ! empty ( $order_items_metas[ $source_order_item_id ] ) ) {
+				$source_order_item_id = $order_items_row['order_item_id'];
+				if ( ! empty( $order_items_metas[ $source_order_item_id ] ) ) {
 					foreach ( $order_items_metas[ $source_order_item_id ] as $order_items_meta ) {
 						$query = $wpdb->prepare(
 							"insert into {$table_prefix_destination}woocommerce_order_itemmeta
 								(order_item_id,meta_key,meta_value)
 								values (%s,%s,%s); ",
 							$order_item_id,
-							$order_items_meta[ 'meta_key' ],
-							$order_items_meta[ 'meta_value' ],
+							$order_items_meta['meta_key'],
+							$order_items_meta['meta_value'],
 						);
-						$res = $wpdb->query( $query );
+						$res   = $wpdb->query( $query );
 						if ( 1 != $res ) {
 							$msg = sprintf( 'ERROR: %s item meta insert error, source order_item_id ID %d', $object_name, $source_order_item_id );
 							$this->log( self::GENERAL_LOG, $msg );
@@ -654,21 +652,21 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceMigrator {
 					values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s); ",
 				$order_item_id,
 				$order_id,
-				$order_product_lookup_row[ 'product_id' ],
-				$order_product_lookup_row[ 'variation_id' ],
+				$order_product_lookup_row['product_id'],
+				$order_product_lookup_row['variation_id'],
 				$customer_id,
-				$order_product_lookup_row[ 'date_created' ],
-				$order_product_lookup_row[ 'product_qty' ],
-				$order_product_lookup_row[ 'product_net_revenue' ],
-				$order_product_lookup_row[ 'product_gross_revenue' ],
-				$order_product_lookup_row[ 'coupon_amount' ],
-				$order_product_lookup_row[ 'tax_amount' ],
-				$order_product_lookup_row[ 'shipping_amount' ],
-				$order_product_lookup_row[ 'shipping_tax_amount' ],
+				$order_product_lookup_row['date_created'],
+				$order_product_lookup_row['product_qty'],
+				$order_product_lookup_row['product_net_revenue'],
+				$order_product_lookup_row['product_gross_revenue'],
+				$order_product_lookup_row['coupon_amount'],
+				$order_product_lookup_row['tax_amount'],
+				$order_product_lookup_row['shipping_amount'],
+				$order_product_lookup_row['shipping_tax_amount'],
 			);
-			$res = $wpdb->query( $query );
+			$res   = $wpdb->query( $query );
 			if ( 1 != $res ) {
-				$msg = sprintf( 'ERROR: %s product lookup insert error, source order_item_id ID %d', $object_name, $order_product_lookup_row[ 'order_item_id' ] );
+				$msg = sprintf( 'ERROR: %s product lookup insert error, source order_item_id ID %d', $object_name, $order_product_lookup_row['order_item_id'] );
 				$this->log( self::GENERAL_LOG, $msg );
 				WP_CLI::warning( $msg );
 			}


### PR DESCRIPTION
This PR adds a new command to migrate WooCommerce Subscriptions payment methods from a given payment method to another.

It currently supports PayPal and Bank Transfers (bacs), we can simply add more payment methods when needed, we just need to make sure we take into consideration moving the payment methods meta (which is not supported today), for example, how to deal with Stripe Customer IDs if we're migrating to PayPal, but I don't think we'll have to deal with such cases.

The command offer also the ability to set the subscription expiry date.