### PR TITLE
Feat/merge co authors

### DIFF
--- a/src/Migrator/General/CoAuthorPlusMigrator.php
+++ b/src/Migrator/General/CoAuthorPlusMigrator.php
@@ -40,7 +40,7 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 	 */
 	private function __construct() {
 		$this->coauthorsplus_logic = new CoAuthorPlus();
-		$this->posts_logic = new Posts();
+		$this->posts_logic         = new Posts();
 	}
 
 	/**
@@ -51,8 +51,7 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 	public static function get_instance() {
 		$class = get_called_class();
 		if ( null === self::$instance ) {
-			self::$instance = new $class;
-
+			self::$instance = new $class();
 		}
 
 		return self::$instance;
@@ -62,187 +61,216 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 	 * See InterfaceMigrator::register_commands.
 	 */
 	public function register_commands() {
-		WP_CLI::add_command( 'newspack-content-migrator co-authors-tags-with-prefix-to-guest-authors', array( $this, 'cmd_tags_with_prefix_to_guest_authors' ), [
-			'shortdesc' => sprintf( "Converts tags with a specific prefix to Guest Authors, in the following way -- runs through all public Posts, and converts tags beginning with %s prefix (this prefix is currently hardcoded) to Co-Authors Plus Guest Authors, and also assigns them to the post as (co-)authors. It completely overwrites the existing list of authors for these Posts.", $this->tag_author_prefix ),
-			'synopsis'  => array(
-				array(
-					'type'        => 'assoc',
-					'name'        => 'unset-author-tags',
-					'description' => 'If used, will unset these author tags from the posts.',
-					'optional'    => true,
-					'repeating'   => false,
+		WP_CLI::add_command(
+            'newspack-content-migrator co-authors-tags-with-prefix-to-guest-authors',
+            array( $this, 'cmd_tags_with_prefix_to_guest_authors' ),
+            [
+				'shortdesc' => sprintf( 'Converts tags with a specific prefix to Guest Authors, in the following way -- runs through all public Posts, and converts tags beginning with %s prefix (this prefix is currently hardcoded) to Co-Authors Plus Guest Authors, and also assigns them to the post as (co-)authors. It completely overwrites the existing list of authors for these Posts.', $this->tag_author_prefix ),
+				'synopsis'  => array(
+					array(
+						'type'        => 'assoc',
+						'name'        => 'unset-author-tags',
+						'description' => 'If used, will unset these author tags from the posts.',
+						'optional'    => true,
+						'repeating'   => false,
+					),
 				),
-			),
-		] );
-		WP_CLI::add_command( 'newspack-content-migrator co-authors-tags-with-taxonomy-to-guest-authors', array( $this, 'cmd_tags_with_taxonomy_to_guest_authors' ), [
-			'shortdesc' => "Converts tags with specified taxonomy to Guest Authors, in the following way -- runs through all the public Posts, gets tags which have a specified taxonomy assigned to them (this taxonomy given here as a positional argument, e.g. 'writer'), and converts these tags to Co-Authors Plus Guest Authors, and also assigns them to the posts as co-authors. It completely overwrites the existing list of authors for these Posts.",
-			'synopsis'  => array(
-				array(
-					'type'        => 'positional',
-					'name'        => 'tag-taxonomy',
-					'description' => 'The tag taxonomy to filter posts by.',
-					'optional'    => false,
-					'repeating'   => false,
+			]
+        );
+		WP_CLI::add_command(
+            'newspack-content-migrator co-authors-tags-with-taxonomy-to-guest-authors',
+            array( $this, 'cmd_tags_with_taxonomy_to_guest_authors' ),
+            [
+				'shortdesc' => "Converts tags with specified taxonomy to Guest Authors, in the following way -- runs through all the public Posts, gets tags which have a specified taxonomy assigned to them (this taxonomy given here as a positional argument, e.g. 'writer'), and converts these tags to Co-Authors Plus Guest Authors, and also assigns them to the posts as co-authors. It completely overwrites the existing list of authors for these Posts.",
+				'synopsis'  => array(
+					array(
+						'type'        => 'positional',
+						'name'        => 'tag-taxonomy',
+						'description' => 'The tag taxonomy to filter posts by.',
+						'optional'    => false,
+						'repeating'   => false,
+					),
 				),
-			),
-		] );
-		WP_CLI::add_command( 'newspack-content-migrator co-authors-cpt-to-guest-authors', array( $this, 'cmd_cpt_to_guest_authors' ), [
-			'shortdesc' => "Converts a CPT used for describing authors to a CAP Guest Authors. The associative arguments tell the command where to find info needed to create the Guest Author objects. For example, the GA's 'display name' could be located in the CPT's 'post_title', the GA's 'description' (bio) could be in the CPT's 'post_content', and the email address in a CPT's meta field called 'author_email' -- and these could all be provided like this: `--display_name=post_title --description=post_content --email=meta:author_email`.",
-			'synopsis'  => [
-				[
-					'type'        => 'positional',
-					'name'        => 'cpt',
-					'description' => 'The slug of the custom post type we want to convert.',
-					'optional'    => false,
-					'repeating'   => false,
+			]
+        );
+		WP_CLI::add_command(
+            'newspack-content-migrator co-authors-cpt-to-guest-authors',
+            array( $this, 'cmd_cpt_to_guest_authors' ),
+            [
+				'shortdesc' => "Converts a CPT used for describing authors to a CAP Guest Authors. The associative arguments tell the command where to find info needed to create the Guest Author objects. For example, the GA's 'display name' could be located in the CPT's 'post_title', the GA's 'description' (bio) could be in the CPT's 'post_content', and the email address in a CPT's meta field called 'author_email' -- and these could all be provided like this: `--display_name=post_title --description=post_content --email=meta:author_email`.",
+				'synopsis'  => [
+					[
+						'type'        => 'positional',
+						'name'        => 'cpt',
+						'description' => 'The slug of the custom post type we want to convert.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'display_name',
+						'description' => 'Where the CPT stores the author\'s display name. This is the only mandatory field for GAs.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'first_name',
+						'description' => 'Where the CPT stores the author\'s first name.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'last_name',
+						'description' => 'Where the CPT stores the author\'s last name.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'email',
+						'description' => 'Where the CPT stores the author\'s email address.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'website',
+						'description' => 'Where the CPT stores the author\'s website address.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'description',
+						'description' => 'Where the CPT stores the author\'s biographical information.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'flag',
+						'name'        => 'dry-run',
+						'description' => 'Do a dry run simulation and don\'t actually create any Guest Authors.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
 				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'display_name',
-					'description' => 'Where the CPT stores the author\'s display name. This is the only mandatory field for GAs.',
-					'optional'    => false,
-					'repeating'   => false,
+			]
+        );
+		WP_CLI::add_command(
+            'newspack-content-migrator co-authors-link-guest-author-to-existing-user',
+            array( $this, 'cmd_link_ga_to_user' ),
+            [
+				'shortdesc' => 'Links a Guest Author to an existing WP User.',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'ga_id',
+						'description' => 'Guest Author ID which will be linked to the existing WP User.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'user_id',
+						'description' => 'WP User ID to which to link the Guest Author to.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
 				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'first_name',
-					'description' => 'Where the CPT stores the author\'s first name.',
-					'optional'    => true,
-					'repeating'   => false,
+			]
+        );
+		WP_CLI::add_command(
+            'newspack-content-migrator co-authors-create-guest-author-and-add-to-post',
+            array( $this, 'cmd_cap_create_guest_author_and_add_to_post' ),
+            [
+				'shortdesc' => 'Create a Co-Authors Plus Guest Author and add it to a post.',
+				'synopsis'  => [
+					[
+						'type'        => 'positional',
+						'name'        => 'postID',
+						'description' => 'Post ID to add guest author to.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'full_name',
+						'description' => 'Guest author\' full name.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'first_name',
+						'description' => 'Guest author\' first name.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'last_name',
+						'description' => 'Guest author\' last name.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'email',
+						'description' => 'Guest author\' email.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'description',
+						'description' => 'Guest author\' description.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
 				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'last_name',
-					'description' => 'Where the CPT stores the author\'s last name.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'email',
-					'description' => 'Where the CPT stores the author\'s email address.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'website',
-					'description' => 'Where the CPT stores the author\'s website address.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'description',
-					'description' => 'Where the CPT stores the author\'s biographical information.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'flag',
-					'name'        => 'dry-run',
-					'description' => 'Do a dry run simulation and don\'t actually create any Guest Authors.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-			],
-		] );
-		WP_CLI::add_command( 'newspack-content-migrator co-authors-link-guest-author-to-existing-user', array( $this, 'cmd_link_ga_to_user' ), [
-			'shortdesc' => "Links a Guest Author to an existing WP User.",
-			'synopsis'  => [
-				[
-					'type'        => 'assoc',
-					'name'        => 'ga_id',
-					'description' => 'Guest Author ID which will be linked to the existing WP User.',
-					'optional'    => false,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'user_id',
-					'description' => 'WP User ID to which to link the Guest Author to.',
-					'optional'    => false,
-					'repeating'   => false,
-				],
-			],
-		] );
-		WP_CLI::add_command( 'newspack-content-migrator co-authors-create-guest-author-and-add-to-post', array( $this, 'cmd_cap_create_guest_author_and_add_to_post' ), [
-			'shortdesc' => "Create a Co-Authors Plus Guest Author and add it to a post.",
-			'synopsis'  => [
-				[
-					'type'        => 'positional',
-					'name'        => 'postID',
-					'description' => 'Post ID to add guest author to.',
-					'optional'    => false,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'full_name',
-					'description' => 'Guest author\' full name.',
-					'optional'    => false,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'first_name',
-					'description' => 'Guest author\' first name.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'last_name',
-					'description' => 'Guest author\' last name.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'email',
-					'description' => 'Guest author\' email.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-				[
-					'type'        => 'assoc',
-					'name'        => 'description',
-					'description' => 'Guest author\' description.',
-					'optional'    => true,
-					'repeating'   => false,
-				],
-			],
-		] );
-		WP_CLI::add_command( 'newspack-content-migrator co-authors-fix-non-unique-guest-slugs', array( $this, 'cmd_cap_fix_non_unique_guest_slugs'), [
-		    'shortdesc' => "Make unique any Guest Author Slug which matches a User's slug."
-        ] );
+			]
+        );
+		WP_CLI::add_command(
+            'newspack-content-migrator co-authors-fix-non-unique-guest-slugs',
+            array( $this, 'cmd_cap_fix_non_unique_guest_slugs' ),
+            [
+				'shortdesc' => "Make unique any Guest Author Slug which matches a User's slug.",
+			]
+        );
 		WP_CLI::add_command(
 			'newspack-content-migrator co-authors-split-to-multiple-coauthors',
 			[ $this, 'cmd_split_guest_author_to_multiple_authors' ],
 			[
 				'shortdesc' => 'Reassigns all posts currently associated to a specific Guest Author to different multiple (or single) Guest Author(s). Example use: `wp newspack-content-migrator co-authors-split-to-multiple-coauthors "Chris Christofersson of NewsSource, with Adam Black of 100 Days in Appalachia" --new-guest-author-names="Chris Christofersson; Adam Black of 100 Days in Appalachia" --delimiter="; "',
-				'synopsis' => [
+				'synopsis'  => [
 					[
-						'type' => 'positional',
-						'name' => 'guest-author',
+						'type'        => 'positional',
+						'name'        => 'guest-author',
 						'description' => 'Target Guest Author (Guest Author Display Name e.g. Edward Carrasco with Newspack, and Ingrid Miller with HR)',
-						'optional' => false,
-						'repeating' => false,
+						'optional'    => false,
+						'repeating'   => false,
 					],
 					[
-						'type' => 'assoc',
-						'name' => 'new-guest-author-names',
+						'type'        => 'assoc',
+						'name'        => 'new-guest-author-names',
 						'description' => "The new guest author's to create (e.g. Edward Carrasco,Ingrid Miller [delimited by comma]). The original GA will be disassociated.",
-						'optional' => false,
-						'repeating' => true,
+						'optional'    => false,
+						'repeating'   => true,
 					],
 					[
-						'type' => 'assoc',
-						'name' => 'delimiter',
+						'type'        => 'assoc',
+						'name'        => 'delimiter',
 						'description' => 'Delimiter to use to split new-guest-authors values.',
-						'optional' => true,
-						'repeating' => false,
-						'default' => ',',
+						'optional'    => true,
+						'repeating'   => false,
+						'default'     => ',',
+					],
+				],
+			]
+		);
+
 					],
 				],
 			]
@@ -288,14 +316,14 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 			$data['user_email'] = sanitize_email( $email );
 		}
 		if ( $description ) {
-		$data['description'] = wp_filter_post_kses( $description );
+			$data['description'] = wp_filter_post_kses( $description );
 		}
 
 		$guest_author = $this->coauthorsplus_logic->get_guest_author_by_user_login( $user_login );
 		if ( $guest_author ) {
 			$author_id = $guest_author->ID;
 		} else {
-			$author_id = $this->coauthorsplus_logic->create_guest_author( $data ) ;
+			$author_id = $this->coauthorsplus_logic->create_guest_author( $data );
 		}
 
 		$this->coauthorsplus_logic->assign_guest_authors_to_post( [ $author_id ], $post_id );
@@ -313,17 +341,17 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 		$this->require_cap_plugin();
 
 		// Associative parameter.
-		$unset_author_tags = isset( $assoc_args[ 'unset-author-tags' ] ) ? true : false;
+		$unset_author_tags = isset( $assoc_args['unset-author-tags'] ) ? true : false;
 
 		// Get all published posts.
-		$args      = array(
+		$args        = array(
 			'post_type'      => 'post',
 			'post_status'    => 'publish',
 			// The WordPress.VIP.PostsPerPage.posts_per_page_posts_per_page coding standard doesn't like '-1' (all posts) for
 			// posts_per_page value, so we'll set it to something really high.
 			'posts_per_page' => 1000000,
 		);
-		$the_query = new WP_Query( $args );
+		$the_query   = new WP_Query( $args );
 		$total_posts = $the_query->found_posts;
 
 		WP_CLI::line( sprintf( "Converting tags beginning with '%s' to Guest Authors for %d total Posts...", $this->tag_author_prefix, $total_posts ) );
@@ -367,8 +395,8 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 		}
 		$tag_taxonomy = $args[0];
 
-		$post_ids = $this->posts_logic->get_posts_with_tag_with_taxonomy( $tag_taxonomy );
-		$total_posts  = count( $post_ids );
+		$post_ids    = $this->posts_logic->get_posts_with_tag_with_taxonomy( $tag_taxonomy );
+		$total_posts = count( $post_ids );
 
 		WP_CLI::line( sprintf( 'Converting author tags beginning with %s and with taxonomy %s to Guest Authors for %d posts.', $this->tag_author_prefix, $tag_taxonomy, $total_posts ) );
 
@@ -419,16 +447,16 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 		if ( null === $cpt_from ) {
 			WP_CLI::error( 'Missing CPT slug.' );
 		}
-		$display_name_from = isset( $assoc_args[ 'display_name' ] ) ? $assoc_args[ 'display_name' ] : null;
+		$display_name_from = isset( $assoc_args['display_name'] ) ? $assoc_args['display_name'] : null;
 		if ( null === $display_name_from ) {
 			WP_CLI::error( "Missing Guest Author's display_name." );
 		}
-		$first_name_from  = isset( $assoc_args[ 'first_name' ] ) && ! empty( $assoc_args[ 'first_name' ] ) ? $assoc_args[ 'first_name' ] : null;
-		$last_name_from   = isset( $assoc_args[ 'last_name' ] ) && ! empty( $assoc_args[ 'last_name' ] ) ? $assoc_args[ 'last_name' ] : null;
-		$email_from       = isset( $assoc_args[ 'email' ] ) && ! empty( $assoc_args[ 'email' ] ) ? $assoc_args[ 'email' ] : null;
-		$website_from     = isset( $assoc_args[ 'website' ] ) && ! empty( $assoc_args[ 'website' ] ) ? $assoc_args[ 'website' ] : null;
-		$description_from = isset( $assoc_args[ 'description' ] ) && ! empty( $assoc_args[ 'description' ] ) ? $assoc_args[ 'description' ] : null;
-		$dry_run          = isset( $assoc_args[ 'dry-run' ] ) ? true : false;
+		$first_name_from  = isset( $assoc_args['first_name'] ) && ! empty( $assoc_args['first_name'] ) ? $assoc_args['first_name'] : null;
+		$last_name_from   = isset( $assoc_args['last_name'] ) && ! empty( $assoc_args['last_name'] ) ? $assoc_args['last_name'] : null;
+		$email_from       = isset( $assoc_args['email'] ) && ! empty( $assoc_args['email'] ) ? $assoc_args['email'] : null;
+		$website_from     = isset( $assoc_args['website'] ) && ! empty( $assoc_args['website'] ) ? $assoc_args['website'] : null;
+		$description_from = isset( $assoc_args['description'] ) && ! empty( $assoc_args['description'] ) ? $assoc_args['description'] : null;
+		$dry_run          = isset( $assoc_args['dry-run'] ) ? true : false;
 
 		// Register the post type temporarily.
 		if ( ! in_array( $cpt_from, get_post_types() ) ) {
@@ -445,21 +473,21 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 			try {
 				$args = [];
 
-				$args[ 'display_name' ] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $display_name_from );
+				$args['display_name'] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $display_name_from );
 				if ( $first_name_from ) {
-					$args[ 'first_name' ] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $first_name_from );
+					$args['first_name'] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $first_name_from );
 				}
 				if ( $last_name_from ) {
-					$args[ 'last_name' ] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $last_name_from );
+					$args['last_name'] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $last_name_from );
 				}
 				if ( $email_from ) {
-					$args[ 'user_email' ] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $email_from );
+					$args['user_email'] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $email_from );
 				}
 				if ( $website_from ) {
-					$args[ 'website' ] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $website_from );
+					$args['website'] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $website_from );
 				}
 				if ( $description_from ) {
-					$args[ 'description' ] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $description_from );
+					$args['description'] = $this->get_cpt_2_ga_cmd_param_value( $cpt, $description_from );
 				}
 
 				if ( true === $dry_run ) {
@@ -471,7 +499,6 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 
 				// Record the original post ID that we migrated from.
 				add_post_meta( $new_guest_author, '_post_migrated_from', $cpt->ID );
-
 			} catch ( \Exception $e ) {
 				$errors[] = sprintf( 'ID %d -- %s', $cpt->ID, $e->getMessage() );
 			}
@@ -486,12 +513,14 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 			WP_CLI::error( 'Done with errors.' );
 		}
 
-		WP_CLI::success( sprintf(
-			'Created %d GAs from total %d CTPs, and had %d errors.',
-			count( $guest_author_ids ),
-			count( $cpts ),
-			count( $errors )
-		) );
+		WP_CLI::success(
+            sprintf(
+                'Created %d GAs from total %d CTPs, and had %d errors.',
+                count( $guest_author_ids ),
+                count( $cpts ),
+                count( $errors )
+            )
+        );
 	}
 
 	/**
@@ -503,15 +532,15 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 	public function cmd_link_ga_to_user( $args, $assoc_args ) {
 		$this->require_cap_plugin();
 
-		$ga_id   = isset( $assoc_args[ 'ga_id' ] ) ? (int) $assoc_args[ 'ga_id' ] : null;
-		$user_id = isset( $assoc_args[ 'user_id' ] ) ? (int) $assoc_args[ 'user_id' ] : null;
+		$ga_id   = isset( $assoc_args['ga_id'] ) ? (int) $assoc_args['ga_id'] : null;
+		$user_id = isset( $assoc_args['user_id'] ) ? (int) $assoc_args['user_id'] : null;
 
 		$guest_author = $this->coauthorsplus_logic->get_guest_author_by( 'ID', $ga_id );
 		$user         = get_user_by( 'id', $user_id );
-		if (  ! $guest_author ) {
+		if ( ! $guest_author ) {
 			WP_CLI::error( sprintf( 'Guest Author by ID %d not found.', $ga_id ) );
 		}
-		if (  ! $user ) {
+		if ( ! $user ) {
 			WP_CLI::error( sprintf( 'WP User by ID %d not found.', $user_id ) );
 		}
 
@@ -600,13 +629,14 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 	}
 
     public function cmd_cap_fix_non_unique_guest_slugs() {
-
-        $authors = ( new WP_User_Query( array(
-            'who'       => 'authors',
-            'fields'    => array(
-                    'user_nicename',
-                ),
-        ) ) )->get_results();
+        $authors = ( new WP_User_Query(
+            array(
+				'who'    => 'authors',
+				'fields' => array(
+					'user_nicename',
+				),
+            )
+        ) )->get_results();
 
         $author_slugs_string = "'" . implode( "', '", wp_list_pluck( $authors, 'user_nicename' ) ) . "'";
 
@@ -623,13 +653,13 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 
         $post_meta_table = "{$wpdb->prefix}postmeta";
 
-        $sql = "SELECT meta_value FROM {$post_meta_table} 
+        $sql = "SELECT meta_value FROM {$post_meta_table}
                 WHERE meta_key = 'cap-user_login'
                 AND meta_value IN ({$author_slugs_string})";
 
         $non_unique_guest_authors = $wpdb->get_col( $sql );
 
-        $updated_slugs = array();
+        $updated_slugs         = array();
         $unable_to_make_unique = array();
 
         $progress = WP_CLI\Utils\make_progress_bar( 'Updating Guest Author Slugs', count( $non_unique_guest_authors ) );
@@ -650,7 +680,7 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
                             'meta_value' => $new_guest_author_slug,
                         ),
                         array(
-                            'meta_key' => 'cap-user_login',
+                            'meta_key'   => 'cap-user_login',
                             'meta_value' => $guest_author,
                         )
                     );
@@ -662,7 +692,7 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
                      * */
                     continue 2;
                 }
-            } while ($attempts > 0);
+            } while ( $attempts > 0 );
 
             /*
              * 3 Attempts failed to generate unique slug. Will report back to console.
@@ -671,12 +701,12 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
         }
         $progress->finish();
 
-        if ( ! empty($unable_to_make_unique) ) {
-            array_unshift( $unable_to_make_unique, "Unable to make the following Guest Author Slugs unique..." );
+        if ( ! empty( $unable_to_make_unique ) ) {
+            array_unshift( $unable_to_make_unique, 'Unable to make the following Guest Author Slugs unique...' );
             WP_CLI::error_multi_line( $unable_to_make_unique );
         }
 
-        WP_CLI::success( "Done!" );
+        WP_CLI::success( 'Done!' );
         foreach ( $updated_slugs as $slug ) {
             WP_CLI::line( $slug );
         }
@@ -689,14 +719,14 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 	 * @param array $assoc_args Named arguments.
 	 */
 	public function cmd_split_guest_author_to_multiple_authors( $args, $assoc_args ) {
-		$old_guest_author = $args[0];
-		$delimiter = $assoc_args['delimiter'];
+		$old_guest_author       = $args[0];
+		$delimiter              = $assoc_args['delimiter'];
 		$new_guest_author_names = explode( $delimiter, $assoc_args['new-guest-author-names'] );
 
 		global $wpdb;
 		global $coauthors_plus;
 
-		$guest_author_posts_sql = "SELECT tr.* FROM $wpdb->term_relationships tr 
+		$guest_author_posts_sql = "SELECT tr.* FROM $wpdb->term_relationships tr
 			INNER JOIN $wpdb->posts p ON tr.object_id = p.ID
 			WHERE tr.term_taxonomy_id IN (
 	            SELECT wtt.term_taxonomy_id FROM $wpdb->term_taxonomy wtt
@@ -705,14 +735,14 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 	                SELECT post_id FROM $wpdb->postmeta WHERE meta_key = 'cap-display_name' AND meta_value = '$old_guest_author'
 	            )
 			) AND p.post_type = 'post'";
-		$results = $wpdb->get_results( $wpdb->prepare( $guest_author_posts_sql ) );
+		$results                = $wpdb->get_results( $wpdb->prepare( $guest_author_posts_sql ) );
 
 		if ( empty( $results ) ) {
-			WP_CLI::success('Target guest author not found.');
-			WP_CLI::halt(1);
+			WP_CLI::success( 'Target guest author not found.' );
+			WP_CLI::halt( 1 );
 		}
 
-		WP_CLI::line("Found result for '$old_guest_author'");
+		WP_CLI::line( "Found result for '$old_guest_author'" );
 
 		$guest_authors = [];
 		foreach ( $new_guest_author_names as $guest_author_name ) {
@@ -737,33 +767,42 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 				}
 			}
 
-			$guest_author = $this->coauthorsplus_logic->coauthors_guest_authors->get_guest_author_by( 'id', $author_id );
+			$guest_author    = $this->coauthorsplus_logic->coauthors_guest_authors->get_guest_author_by( 'id', $author_id );
 			$guest_authors[] = $guest_author->user_nicename;
 		}
 
 		foreach ( $results as $relationship ) {
-			WP_CLI::line("Adding Guest Authors to Post ID: $relationship->object_id ");
+			WP_CLI::line( "Adding Guest Authors to Post ID: $relationship->object_id " );
 			$coauthors_plus->add_coauthors( $relationship->object_id, $guest_authors, true );
 
 			$wpdb->delete(
 				$wpdb->term_relationships,
 				[
 					'term_taxonomy_id' => $relationship->term_taxonomy_id,
-					'object_id' => $relationship->object_id,
+					'object_id'        => $relationship->object_id,
 				]
 			);
 		}
 
 		foreach ( $guest_authors as $guest_author ) {
-			$guest_author_term_taxonomy = $wpdb->get_row( "SELECT * FROM $wpdb->term_taxonomy 
-				WHERE taxonomy = 'author' AND description LIKE '%$guest_author%'" );
+			$guest_author_term_taxonomy = $wpdb->get_row(
+                "SELECT * FROM $wpdb->term_taxonomy
+				WHERE taxonomy = 'author' AND description LIKE '%$guest_author%'"
+            );
 
-			$wpdb->query("UPDATE $wpdb->term_taxonomy SET count = (
+			$wpdb->query(
+                "UPDATE $wpdb->term_taxonomy SET count = (
     			SELECT COUNT(tr.object_id) FROM $wpdb->term_relationships AS tr
     			INNER JOIN $wpdb->posts AS p ON tr.object_id = p.ID
     			WHERE tr.term_taxonomy_id = $guest_author_term_taxonomy->term_taxonomy_id
     			AND p.post_type = 'post'
-			) WHERE term_taxonomy_id = $guest_author_term_taxonomy->term_taxonomy_id");
+			) WHERE term_taxonomy_id = $guest_author_term_taxonomy->term_taxonomy_id"
+            );
+		}
+
+		WP_CLI::success( 'Done' );
+	}
+
 		}
 
 		WP_CLI::success('Done');
@@ -776,8 +815,8 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
      * @return string
      */
 	private function readable_random_string( int $length = 8 ) {
-        $string = '';
-        $vowels = array(
+        $string     = '';
+        $vowels     = array(
             'a',
             'e',
             'i',
@@ -809,8 +848,8 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 
         $max = $length / 2;
         for ( $i = 1; $i <= $max; $i++ ) {
-            $string .= $consonants[rand(0,19)];
-            $string .= $vowels[rand(0,4)];
+            $string .= $consonants[ rand( 0, 19 ) ];
+            $string .= $vowels[ rand( 0, 4 ) ];
         }
 
         return $string;
@@ -883,19 +922,19 @@ class CoAuthorPlusMigrator implements InterfaceMigrator {
 	 * @return array WP_Post
 	 */
 	private function get_posts( $post_type ) {
-
-		$posts = get_posts( [
-			'post_type'      => $post_type,
-			'posts_per_page' => -1,
-			'post_status'    => 'any',
-		] );
+		$posts = get_posts(
+            [
+				'post_type'      => $post_type,
+				'posts_per_page' => -1,
+				'post_status'    => 'any',
+			]
+        );
 
 		if ( empty( $posts ) ) {
 			WP_CLI::error( sprintf( "No '%s' post types found!", $post_type ) );
 		}
 
 		return $posts;
-
 	}
 
 }


### PR DESCRIPTION
This adds a command to merge co-authors, as often we migrate the bylines for the same authors with a typo on the name.

The command can be used as follow:
```
wp newspack-content-migrator co-authors-merge-coauthors --guest-author-id=123 --guest-authors-to-remove-ids=456,789
```

Where the co-authors with the IDs `456`, and `789` are going to be removed, and their content reassigned to the co-author with the ID `123`. 