### PR TITLE
A fix for Content Diff updating of Attachment IDs

### DIFF
--- a/src/Migrator/General/ContentDiffMigrator.php
+++ b/src/Migrator/General/ContentDiffMigrator.php
@@ -527,6 +527,17 @@ class ContentDiffMigrator implements InterfaceMigrator {
 	public function update_featured_image_ids( $imported_posts_data ) {
 
 		/**
+		 * Helper map of imported Posts and Pages.
+		 *
+		 * @var array $imported_post_ids_map Keys are old Live IDs, values are new local IDs.
+		 */
+		$imported_post_ids_map    = [];
+		$imported_posts_data_post = $this->filter_log_data_array( $imported_posts_data, [ 'post_type' => [ 'post', 'page' ] ], false );
+		foreach ( $imported_posts_data_post as $entry ) {
+			$imported_post_ids_map[ $entry['id_old'] ] = $entry['id_new'];
+		}
+
+		/**
 		 * Helper map of imported Attachments.
 		 *
 		 * @var array $imported_attachment_ids_map Keys are old Live IDs, values are new local IDs.
@@ -557,7 +568,7 @@ class ContentDiffMigrator implements InterfaceMigrator {
 			$attachment_ids_for_featured_image_update = array_values( $attachment_ids_for_featured_image_update );
 			echo "\n" . sprintf( '%s of total %d attachments IDs already had their featured images imported, continuing from there..', count( $imported_attachment_ids_map ) - count( $attachment_ids_for_featured_image_update ), count( $imported_attachment_ids_map ) );
 		}
-		self::$logic->update_featured_images( $attachment_ids_for_featured_image_update, $imported_attachment_ids_map, $this->log_updated_featured_imgs_ids );
+		self::$logic->update_featured_images( $imported_post_ids_map, $attachment_ids_for_featured_image_update, $imported_attachment_ids_map, $this->log_updated_featured_imgs_ids );
 	}
 
 	/**

--- a/src/Migrator/General/ContentDiffMigrator.php
+++ b/src/Migrator/General/ContentDiffMigrator.php
@@ -720,6 +720,7 @@ class ContentDiffMigrator implements InterfaceMigrator {
 		$live_posts_table = $this->live_table_prefix . 'posts';
 		$posts_table      = $wpdb->posts;
 
+		// phpcs:disable -- wpdb::prepare is used correctly.
 		$parent_id_new = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT wp.ID
@@ -734,6 +735,7 @@ class ContentDiffMigrator implements InterfaceMigrator {
 				$id_live
 			)
 		);
+		// phpcs:enable
 
 		return $parent_id_new;
 	}


### PR DESCRIPTION
Content importer should only update the newly imported Posts' att.ID, not modify the existing Posts' attachment IDs. This PR fixes that.

This bug wasn't visible previously, because it only affects external sites which use same attachment IDs that also exist on the Staging site. An example such as this is most apparent in completely separate content archives, like additional archive sites with completely separate contents, but would not be visible if a preexisting content on Staging (like Newspack pages) didn't use the same IDs, and if it didn't use featured images (attachment IDs).

An example:
- if a Staging has an existing Post 111 with attachment 123,
- and the external archive site ("live DB") has another Post 33333 with same attachment ID 123 (but this is a different attachment file), once this Post gets imported, both the Post ID will change, e.g. 44444, and the attachment ID will change too, e.g. 456
- when updating attachment ID 123 to 456, we should only do so for the newly imported post 44444, but not for the old existing post 123
- and this PR fixes that