### PR TITLE
Add/content diff error prevention

### DIFF
--- a/src/MigrationLogic/ContentDiffMigrator.php
+++ b/src/MigrationLogic/ContentDiffMigrator.php
@@ -142,10 +142,12 @@ class ContentDiffMigrator {
 		$data[ self::DATAKEY_USERS ][] = $author_row;
 
 		// Get Post Author User Metas.
-		$data[ self::DATAKEY_USERMETA ] = array_merge(
-			$data[ self::DATAKEY_USERMETA ],
-			$this->select_usermeta_rows( $table_prefix, $author_row['ID'] )
-		);
+		if ( is_array( $author_row ) && array_key_exists( 'ID', $author_row ) ) {
+			$data[ self::DATAKEY_USERMETA ] = array_merge(
+				$data[ self::DATAKEY_USERMETA ],
+				$this->select_usermeta_rows( $table_prefix, $author_row['ID'] )
+			);
+		}
 
 		// Get Comments.
 		if ( $post_row['comment_count'] > 0 ) {
@@ -319,9 +321,9 @@ class ContentDiffMigrator {
 
 		// Get existing Author User or insert a new one.
 		$author_id_old = $data[ self::DATAKEY_POST ]['post_author'];
-		$author_row    = $this->filter_array_element( $data[ self::DATAKEY_USERS ], 'ID', $author_id_old );
-		$usermeta_rows = $this->filter_array_elements( $data[ self::DATAKEY_USERMETA ], 'user_id', $author_row['ID'] );
-		$user_existing = $this->get_user_by( 'login', $author_row['user_login'] );
+		$author_row    = ! is_null( $author_id_old ) ? $this->filter_array_element( $data[ self::DATAKEY_USERS ], 'ID', $author_id_old ) : [];
+		$usermeta_rows = is_array( $author_row ) && array_key_exists( 'ID', $author_row ) ? $this->filter_array_elements( $data[ self::DATAKEY_USERMETA ], 'user_id', $author_row['ID'] ) : [];
+		$user_existing = is_array( $author_row ) && array_key_exists( 'user_login', $author_row ) ? $this->get_user_by( 'login', $author_row['user_login'] ) : false;
 		$author_id_new = null;
 		if ( $user_existing instanceof WP_User ) {
 			$author_id_new = (int) $user_existing->ID;

--- a/src/Migrator/General/ContentDiffMigrator.php
+++ b/src/Migrator/General/ContentDiffMigrator.php
@@ -471,7 +471,7 @@ class ContentDiffMigrator implements InterfaceMigrator {
 
 			$parent_id_old = $post->post_parent;
 			$parent_id_new = $imported_post_ids_map[ $post->post_parent ] ?? null;
-			$parent_id_new = is_null( $parent_id_new ) ? $imported_attachment_ids_map[ $post->post_parent ] : $parent_id_new;
+			$parent_id_new = is_null( $parent_id_new ) & array_key_exists( $post->post_parent, $imported_attachment_ids_map ) ? $imported_attachment_ids_map[ $post->post_parent ] : $parent_id_new;
 
 			// It's possible that this $post's post_parent already existed in local DB before the Content Diff import was run, so
 			// it won't be present in the list of the posts we imported, $all_live_posts_ids. So let's try and search for this


### PR DESCRIPTION
To reproduce these errors, download the following SQL export from [berkeleyside-staging.newspackstaging.com](http://berkeleyside-staging.newspackstaging.com/): /tmp/db_backups/149658774_latin1_2022-07-26_13-46_with_live_tables.sql . Then run the content-diff commands:
```
wp newspack-content-migrator content-diff-search-new-content-on-live --export-dir=/tmp/content_migration --live-table-prefix=wp_live_
wp newspack-content-migrator content-diff-migrate-live-content --import-dir=/tmp/content_migration --live-table-prefix=wp_live
```

During the recent content-refresh of Berkeleyside, I witnessed the following errors:
`Trying to access array offset on value of type null in /srv/htdocs/wp-content/plugins/newspack-custom-content-migrator/src/MigrationLogic/ContentDiffMigrator.php on line 147
Notice: Trying to access array offset on value of type null in /srv/htdocs/wp-content/plugins/newspack-custom-content-migrator/src/MigrationLogic/ContentDiffMigrator.php on line 323
Notice: Trying to access array offset on value of type null in /srv/htdocs/wp-content/plugins/newspack-custom-content-migrator/src/MigrationLogic/ContentDiffMigrator.php on line 324`

Upon further inspection I found that it was due to certain expectations of values, which in this case were not available. This was preventing posts from being inserted brought over from the live data set. This PR addresses the instances where these values are expected, but not available.