### PR TITLE
detect broken attachments URLs in posts content

### DIFF
--- a/src/MigrationLogic/Attachments.php
+++ b/src/MigrationLogic/Attachments.php
@@ -136,8 +136,8 @@ class Attachments {
 							WP_CLI::warning(
 								sprintf(
 									'Image ID (%s) from S3 returned an error: %s',
-									$image_request_from_s3,
-									$image_request->get_error_message()
+									$s3_url,
+									$image_request_from_s3->get_error_message()
 								)
 							);
 						}

--- a/src/MigrationLogic/Attachments.php
+++ b/src/MigrationLogic/Attachments.php
@@ -54,24 +54,24 @@ class Attachments {
 			copy( $path, $tmpfname );
 		}
 		$file_array = [
-			'name' => wp_basename( $path ),
+			'name'     => wp_basename( $path ),
 			'tmp_name' => $tmpfname,
 		];
 
 		if ( $title ) {
-			$args[ 'post_title' ] = $title;
+			$args['post_title'] = $title;
 		}
 		if ( $caption ) {
-			$args[ 'post_excerpt' ] = $caption;
+			$args['post_excerpt'] = $caption;
 		}
 		if ( $description ) {
-			$args[ 'post_content' ] = $description;
+			$args['post_content'] = $description;
 		}
 		$att_id = media_handle_sideload( $file_array, $post_id, $title, $args );
 
 		// If this was a download and there was an error then clean up the temp file.
 		if ( is_wp_error( $att_id ) && $is_http ) {
-			@unlink( $file_array[ 'tmp_name' ] );
+			@unlink( $file_array['tmp_name'] );
 		}
 
 		if ( $alt ) {

--- a/src/MigrationLogic/Attachments.php
+++ b/src/MigrationLogic/Attachments.php
@@ -80,4 +80,82 @@ class Attachments {
 
 		return $att_id;
 	}
+
+	/**
+	 * Return broken attachment URLs from posts.
+	 *
+	 * @param int[] $post_ids The post IDs we need to check the images in their content, if not set, the function looks for all the posts in the database.
+	 *
+	 * @return mixed[] Array of the broken URLs indexed by the post IDs.
+	 */
+	public function get_broken_attachment_urls_from_posts( $post_ids = [] ) {
+		$broken_images = [];
+
+		$posts = get_posts(
+            [
+				'posts_per_page' => -1,
+				'post_type'      => 'post',
+				'post_status'    => array( 'publish', 'future', 'draft', 'pending', 'private', 'inherit' ),
+				'post__in'       => $post_ids,
+			]
+        );
+
+		$total_posts = count( $posts );
+		foreach ( $posts as $index => $post ) {
+			WP_CLI::line( sprintf( 'Checking Post(%d/%d): %d', $index + 1, $total_posts, $post->ID ) );
+			$broken_post_images = [];
+
+			preg_match_all( '/<img[^>]+(?:src|data-orig-file)="([^">]+)"/', $post->post_content, $image_sources_match );
+
+			foreach ( $image_sources_match[1] as $image_source_match ) {
+				$image_request = wp_remote_head( $image_source_match, [ 'redirection' => 5 ] );
+
+				if ( is_wp_error( $image_request ) ) {
+					WP_CLI::warning(
+                        sprintf(
+                            'Local image ID (%s) returned an error: %s',
+                            $image_source_match,
+                            $image_request->get_error_message()
+                        )
+                    );
+				}
+
+				if ( 200 !== $image_request['response']['code'] ) {
+					// Check if the URL is managed by s3_uploads plugin.
+					if ( class_exists( S3_Uploads_Plugin::class ) ) {
+						$bucket       = \S3_Uploads\Plugin::get_instance()->get_s3_bucket();
+						$exploded_url = explode( '/', $image_source_match );
+						$filename     = end( $exploded_url );
+						$month        = prev( $exploded_url );
+						$year         = prev( $exploded_url );
+						$s3_url       = 'https://' . $bucket . ".s3.amazonaws.com/wp-content/uploads/$year/$month/$filename";
+
+						$image_request_from_s3 = wp_remote_head( $s3_url, [ 'redirection' => 5 ] );
+
+						if ( is_wp_error( $image_request_from_s3 ) ) {
+							WP_CLI::warning(
+								sprintf(
+									'Image ID (%s) from S3 returned an error: %s',
+									$image_request_from_s3,
+									$image_request->get_error_message()
+								)
+							);
+						}
+
+						if ( 200 !== $image_request_from_s3['response']['code'] ) {
+							$broken_post_images[] = $image_source_match;
+						}
+					} else {
+						$broken_post_images[] = $image_source_match;
+					}
+				}
+			}
+
+			if ( ! empty( $broken_post_images ) ) {
+				$broken_images[ $post->ID ] = $broken_post_images;
+			}
+		}
+
+		return $broken_images;
+	}
 }

--- a/src/MigrationLogic/Attachments.php
+++ b/src/MigrationLogic/Attachments.php
@@ -122,7 +122,7 @@ class Attachments {
 
 				if ( 200 !== $image_request['response']['code'] ) {
 					// Check if the URL is managed by s3_uploads plugin.
-					if ( class_exists( S3_Uploads_Plugin::class ) ) {
+					if ( class_exists( \S3_Uploads\Plugin::class ) ) {
 						$bucket       = \S3_Uploads\Plugin::get_instance()->get_s3_bucket();
 						$exploded_url = explode( '/', $image_source_match );
 						$filename     = end( $exploded_url );

--- a/src/Migrator/General/AttachmentsMigrator.php
+++ b/src/Migrator/General/AttachmentsMigrator.php
@@ -8,7 +8,6 @@
 namespace NewspackCustomContentMigrator\Migrator\General;
 
 use \NewspackCustomContentMigrator\Migrator\InterfaceMigrator;
-use \NewspackCustomContentMigrator\MigrationLogic\Attachments as AttachmentsLogic;
 use \WP_CLI;
 
 /**
@@ -19,23 +18,11 @@ class AttachmentsMigrator implements InterfaceMigrator {
 	const S3_ATTACHMENTS_URLS_LOG = 'S3_ATTACHMENTS_URLS.log';
 
 	/**
-	 * @var AttachmentsLogic
-	 */
-	private $attachments_logic = null;
-
-	/**
 	 * Singleton instance.
 	 *
 	 * @var null|InterfaceMigrator Instance.
 	 */
 	private static $instance = null;
-
-	/**
-	 * Constructor.
-	 */
-	private function __construct() {
-		$this->attachments_logic = new AttachmentsLogic();
-	}
 
 	/**
 	 * Singleton get_instance().
@@ -82,11 +69,6 @@ class AttachmentsMigrator implements InterfaceMigrator {
 					],
 				],
 			]
-		);
-
-		WP_CLI::add_command(
-			'newspack-content-migrator attachments-get-broken-media-urls',
-			[ $this, 'cmd_get_broken_media_urls' ],
 		);
 	}
 
@@ -246,39 +228,6 @@ class AttachmentsMigrator implements InterfaceMigrator {
 		}
 
 		wp_cache_flush();
-	}
-
-	/**
-	 * Gets a list of broken media.
-	 *
-	 * @param array $pos_args   Positional arguments.
-	 * @param array $assoc_args Associative Arguments.
-	 *
-	 * @return void
-	 */
-	public function cmd_get_broken_media_urls( $pos_args, $assoc_args ) {
-		$result = $this->attachments_logic->get_broken_attachment_urls_from_posts( [], true );
-		// $result = $this->attachments_logic->get_broken_attachment_urls_from_posts( [ 430184 ] );
-		print_r( $result );
-		die();
-		foreach ( $result as $post_id => $broken_urls ) {
-			$post                 = get_post( $post_id );
-			$updated_post_content = $post->post_content;
-
-			foreach ( $result as $post_id => $broken_urls ) {
-				foreach ( $broken_urls as $broken_url ) {
-					$fixed_url = $this->get_fixed_url( $broken_url );
-					if ( $fixed_url !== $broken_url ) {
-						$updated_post_content = str_replace( $broken_url, $fixed_url, $updated_post_content );
-					}
-				}
-			}
-
-			if ( $updated_post_content !== $post->post_content ) {
-				// update post
-			}
-		}
-		print_r( $result );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds `get_broken_attachment_urls_from_posts` method to the `Attachments` logic class, it returns broken URLs indexed by post IDs. 

The function takes into consideration the usage of [s3_uploads](https://github.com/humanmade/S3-Uploads) plugin which switches the image URL on the fly when we're rendering the post frontend (with `the_content` filter).

This can be used in something like this:

```php
use \NewspackCustomContentMigrator\MigrationLogic\Attachments as AttachmentsLogic;

// ...

$result = $this->attachments_logic->get_broken_attachments_urls_from_posts_content();
// $result = $this->attachments_logic->get_broken_attachments_urls_from_posts_content( [ 443372, 440745 ] );
foreach($result as $post_id => $broken_urls) {
	$post = get_post($post_id);
	$updated_post_content = $post->post_content;

	foreach($result as $post_id => $broken_urls) {
		foreach($broken_urls as $broken_url) {
			$fixed_url = $this->get_fixed_url($broken_url);
			if($fixed_url !== $broken_url) {
				$updated_post_content = str_replace($broken_url, $fixed_url, $updated_post_content);
			}
		}	
	}	

	if($updated_post_content !== $post->post_content) {
		// update post
	}
}
```