### PR TITLE
feat(SubtitleMigrator): allow to copy exceprt instead of moving it to post subtitle

### DIFF
--- a/src/Migrator/General/SubtitleMigrator.php
+++ b/src/Migrator/General/SubtitleMigrator.php
@@ -12,7 +12,7 @@ class SubtitleMigrator implements InterfaceMigrator {
 	 *
 	 * @var string
 	 */
-	CONST NEWSPACK_SUBTITLE_META_FIELD = 'newspack_post_subtitle';
+	const NEWSPACK_SUBTITLE_META_FIELD = 'newspack_post_subtitle';
 
 	/**
 	 * @var null|InterfaceMigrator Instance.
@@ -33,7 +33,7 @@ class SubtitleMigrator implements InterfaceMigrator {
 	public static function get_instance() {
 		$class = get_called_class();
 		if ( null === self::$instance ) {
-			self::$instance = new $class;
+			self::$instance = new $class();
 		}
 
 		return self::$instance;
@@ -48,6 +48,15 @@ class SubtitleMigrator implements InterfaceMigrator {
 			[ $this, 'cmd_migrate_excerpt_to_subtitle' ],
 			[
 				'shortdesc' => 'Convert all post excerpts into post subtitles.',
+				'synopsis'  => [
+					[
+						'type'        => 'flag',
+						'name'        => 'keep-excerpts-content',
+						'description' => 'If this flag is set, the command will copy the excerpt content to the post subtitle without removing it from the post excerpt.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+				],
 			]
 		);
 	}
@@ -55,21 +64,25 @@ class SubtitleMigrator implements InterfaceMigrator {
 	/**
 	 * Migrate all post excerpts into the subtitle field.
 	 */
-	public function cmd_migrate_excerpt_to_subtitle() {
+	public function cmd_migrate_excerpt_to_subtitle( $args, $assoc_args ) {
 		global $wpdb;
+
+		$keep_excerpts_content = isset( $assoc_args['keep-excerpts-content'] ) ? true : false;
 
 		$data = $wpdb->get_results( "SELECT ID, post_excerpt FROM $wpdb->posts WHERE post_type='post' AND post_excerpt != ''", ARRAY_A );
 
 		foreach ( $data as $post_data ) {
-			if ( empty( trim ( $post_data['post_excerpt'] ) ) ) {
+			if ( empty( trim( $post_data['post_excerpt'] ) ) ) {
 				continue;
 			}
 
 			update_post_meta( $post_data['ID'], self::NEWSPACK_SUBTITLE_META_FIELD, $post_data['post_excerpt'] );
-			WP_CLI::line( "Updated: " . $post_data['ID'] );
+			WP_CLI::line( 'Updated: ' . $post_data['ID'] );
 		}
 
-		$wpdb->query( "UPDATE $wpdb->posts SET post_excerpt = '' WHERE post_type = 'post'" );
+		if ( ! $keep_excerpts_content ) {
+			$wpdb->query( "UPDATE $wpdb->posts SET post_excerpt = '' WHERE post_type = 'post' AND ID = {$post_data['ID']}" );
+		}
 
 		wp_cache_flush();
 		WP_CLI::success( 'Done.' );


### PR DESCRIPTION
This PR adds a flag to the `cmd_migrate_excerpt_to_subtitle` command to allow copying excerpts to the post subtitles instead of only moving them.