### PR TITLE
feat: prevent content-diff from erroneously declaring no posts to refresh.

### DIFF
--- a/src/MigrationLogic/ContentDiffMigrator.php
+++ b/src/MigrationLogic/ContentDiffMigrator.php
@@ -1543,7 +1543,7 @@ class ContentDiffMigrator {
 	 * @throws \RuntimeException
 	 */
 	public function copy_table_data_using_proper_collation( string $prefix, string $table, int $records_per_transaction = 5000, int $sleep_in_seconds = 1, string $prefix_for_backup = 'bak_' ) {
-		$backup_table = esc_sql( $prefix_for_backup . $table );
+		$backup_table = esc_sql( $prefix_for_backup . $prefix . $table );
 		$source_table = esc_sql( $prefix . $table );
 		$match_collation_for_table = esc_sql( $this->wpdb->prefix . $table );
 		$rename_sql = "RENAME TABLE $source_table TO $backup_table";

--- a/src/MigrationLogic/ContentDiffMigrator.php
+++ b/src/MigrationLogic/ContentDiffMigrator.php
@@ -66,11 +66,12 @@ class ContentDiffMigrator {
 	 *
 	 * @param string $live_table_prefix Table prefix for the Live Site.
 	 *
+	 * @throws \RuntimeException Throws exception if any live tables do not match the collation of their corresponding Core WP DB table.
 	 * @return array Result from $wpdb->get_results.
 	 */
 	public function get_live_diff_content_ids( $live_table_prefix ) {
 		if ( ! $this->are_table_collations_matching( $live_table_prefix ) ) {
-			throw new \RuntimeException( "Table collations do not match for some (or all) WP tables." );
+			throw new \RuntimeException( 'Table collations do not match for some (or all) WP tables.' );
 		}
 
 		$ids              = [];
@@ -1436,12 +1437,12 @@ class ContentDiffMigrator {
 	 * migration is necessary.
 	 *
 	 * @param string $table_prefix Table prefix.
-	 * @param array $skip_tables Core WP DB tables to skip (without prefix).
+	 * @param array  $skip_tables Core WP DB tables to skip (without prefix).
 	 *
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Throws exception if unable to find live tables with given prefix.
 	 * @return array
 	 */
-	public function validate_collation_on_content_diff_tables( string $table_prefix, array $skip_tables = [] ): array {
+	public function get_collation_comparison_of_live_and_core_wp_tables( string $table_prefix, array $skip_tables = [] ): array {
 		$validated_tables = [];
 
 		$core_tables = array_diff( self::CORE_WP_TABLES, $skip_tables );
@@ -1470,7 +1471,7 @@ class ContentDiffMigrator {
 		}
 
 		if ( empty( $validated_tables ) ) {
-			throw new \RuntimeException( "Unable to validate collation on content diff tables. Please verify live table prefix." );
+			throw new \RuntimeException( 'Unable to validate collation on content diff tables. Please verify live table prefix.' );
 		}
 
 		return $validated_tables;
@@ -1498,9 +1499,9 @@ class ContentDiffMigrator {
 	 * DB tables have matching collations with their corresponding Core WP DB tables.
 	 *
 	 * @param string $table_prefix Table prefix.
-	 * @param array $skip_tables Core WP DB tables to skip (without prefix).
+	 * @param array  $skip_tables Core WP DB tables to skip (without prefix).
 	 *
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Throws exception if unable to find live tables with given prefix.
 	 * @return bool
 	 */
 	public function are_table_collations_matching( string $table_prefix, array $skip_tables = [] ): bool {
@@ -1517,7 +1518,7 @@ class ContentDiffMigrator {
 	 * @param int    $sleep_in_seconds Delay in seconds between each DB transaction.
 	 * @param string $prefix_for_backup Custom prefix for table to be backed up to.
 	 *
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException Throws various exceptions if unable to complete required SQL operations.
 	 */
 	public function copy_table_data_using_proper_collation( string $prefix, string $table, int $records_per_transaction = 5000, int $sleep_in_seconds = 1, string $prefix_for_backup = 'bak_' ) {
 		$backup_table = esc_sql( $prefix_for_backup . $prefix . $table );

--- a/src/Migrator/General/ContentDiffMigrator.php
+++ b/src/Migrator/General/ContentDiffMigrator.php
@@ -728,7 +728,11 @@ class ContentDiffMigrator implements InterfaceMigrator {
 
 		$tables = self::$logic->get_validated_collation_tables( $different_tables_only );
 
-		WP_CLI\Utils\format_items( 'table', $tables, array_keys( $tables[0] ) );
+		if ( ! empty( $tables ) ) {
+			WP_CLI\Utils\format_items( 'table', $tables, array_keys( $tables[0] ) );
+		} else {
+			WP_CLI::success( 'Live and Core WP DB table collations match!' );
+		}
 	}
 
 	/**

--- a/src/Migrator/General/ContentDiffMigrator.php
+++ b/src/Migrator/General/ContentDiffMigrator.php
@@ -154,6 +154,82 @@ class ContentDiffMigrator implements InterfaceMigrator {
 				],
 			]
 		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator display-collations-comparison',
+			[ $this, 'cmd_compare_collations_of_live_and_core_wp_tables' ],
+			[
+				'shortdesc' => 'Display a table comparing collations of Live and Core WP tables.',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'live-table-prefix',
+						'description' => 'Live site table prefix.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'skip-tables',
+						'description' => 'Skip checking a particular set of tables from the collation checks.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'flag',
+						'name'        => 'different-collations-only',
+						'description' => 'This flag determines to only display tables with differing collations.',
+						'optional'    => true,
+					],
+				],
+			]
+		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator correct-collations-for-live-wp-tables',
+			[ $this, 'cmd_correct_collations_for_live_wp_tables' ],
+			[
+				'shortdesc' => 'This command will handle the necessary operations to match collations across Live and Core WP tables',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'live-table-prefix',
+						'description' => 'Live site table prefix.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'mode',
+						'description' => 'Determines how large the SQL insert transactions are and the latency between them.',
+						'optional'    => true,
+						'default'     => 'generous',
+						'options'     => [
+							'aggressive',
+							'generous',
+							'cautious',
+							'calm',
+						],
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'skip-tables',
+						'description' => 'Skip checking a particular set of tables from the collation checks.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'backup-table-prefix',
+						'description' => 'Prefix to use when backing up the Live tables.',
+						'optional'    => true,
+						'default'     => 'bak_',
+						'repeating'   => false,
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -631,6 +707,77 @@ class ContentDiffMigrator implements InterfaceMigrator {
 		}
 
 		self::$logic->update_blocks_ids( $new_post_ids_for_blocks_update, $imported_attachment_ids_map, $this->log_updated_blocks_ids );
+	}
+
+	/**
+	 * This function will display a table comparing the collations of Live and Core WP tables.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Optional arguments.
+	 */
+	public function cmd_compare_collations_of_live_and_core_wp_tables( $args, $assoc_args ) {
+		$live_table_prefix = $assoc_args['live-table-prefix'];
+		$skip_tables = [];
+		$different_tables_only = $assoc_args['different-collations-only'] ?? false;
+
+		if ( ! empty( $assoc_args['skip-tables'] ) ) {
+			$skip_tables = explode( ',', $assoc_args['skip-tables'] );
+		}
+
+		self::$logic->validate_collation_on_content_diff_tables( $live_table_prefix, $skip_tables );
+
+		$tables = self::$logic->get_validated_collation_tables( $different_tables_only );
+
+		WP_CLI\Utils\format_items( 'table', $tables, array_keys( $tables[0] ) );
+	}
+
+	/**
+	 * This function will execute the necessary steps to get Live WP
+	 * tables to match the collation of Core WP tables.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Optional arguments.
+	 */
+	public function cmd_correct_collations_for_live_wp_tables( $args, $assoc_args ) {
+		$live_table_prefix = $assoc_args['live-table-prefix'];
+		$mode = $assoc_args['mode'];
+		$backup_prefix = $assoc_args['backup-table-prefix'];
+		$skip_tables = [];
+
+		if ( ! empty( $assoc_args['skip-tables'] ) ) {
+			$skip_tables = explode( ',', $assoc_args['skip-tables'] );
+		}
+
+		self::$logic->validate_collation_on_content_diff_tables( $live_table_prefix, $skip_tables );
+		$tables_with_differing_collations = self::$logic->get_validated_collation_tables( true );
+
+		if ( ! empty( $tables_with_differing_collations ) ) {
+			WP_CLI\Utils\format_items( 'table', $tables_with_differing_collations, array_keys( $tables_with_differing_collations[0] ) );
+		}
+
+		switch ( $mode ) {
+			case 'aggressive':
+				$records_per_transaction = 15000;
+				$sleep_in_seconds = 1;
+				break;
+			case 'generous':
+				$records_per_transaction = 10000;
+				$sleep_in_seconds = 2;
+				break;
+			case 'calm':
+				$records_per_transaction = 1000;
+				$sleep_in_seconds = 3;
+				break;
+			default: // Cautious.
+				$records_per_transaction = 5000;
+				$sleep_in_seconds = 2;
+				break;
+		}
+
+		foreach ( $tables_with_differing_collations as $result ) {
+			echo 'Addressing ' . $result['table'] . "\n";
+			self::$logic->copy_table_data_using_proper_collation( $live_table_prefix, $result['table'], $records_per_transaction, $sleep_in_seconds, $backup_prefix );
+		}
 	}
 
 	/**

--- a/src/Migrator/General/ContentDiffMigrator.php
+++ b/src/Migrator/General/ContentDiffMigrator.php
@@ -724,9 +724,13 @@ class ContentDiffMigrator implements InterfaceMigrator {
 			$skip_tables = explode( ',', $assoc_args['skip-tables'] );
 		}
 
-		self::$logic->validate_collation_on_content_diff_tables( $live_table_prefix, $skip_tables );
+		$tables = [];
 
-		$tables = self::$logic->get_validated_collation_tables( $different_tables_only );
+		if ( $different_tables_only ) {
+			$tables = self::$logic->filter_for_different_collated_tables( $live_table_prefix, $skip_tables );
+		} else {
+			$tables = self::$logic->get_collation_comparison_of_live_and_core_wp_tables( $live_table_prefix, $skip_tables );
+		}
 
 		if ( ! empty( $tables ) ) {
 			WP_CLI\Utils\format_items( 'table', $tables, array_keys( $tables[0] ) );
@@ -752,8 +756,7 @@ class ContentDiffMigrator implements InterfaceMigrator {
 			$skip_tables = explode( ',', $assoc_args['skip-tables'] );
 		}
 
-		self::$logic->validate_collation_on_content_diff_tables( $live_table_prefix, $skip_tables );
-		$tables_with_differing_collations = self::$logic->get_validated_collation_tables( true );
+		$tables_with_differing_collations = self::$logic->filter_for_different_collated_tables( $live_table_prefix, $skip_tables );
 
 		if ( ! empty( $tables_with_differing_collations ) ) {
 			WP_CLI\Utils\format_items( 'table', $tables_with_differing_collations, array_keys( $tables_with_differing_collations[0] ) );


### PR DESCRIPTION
This body of work will detect if table collations are different between live and core WP DB tables. If they are, this work will be able to execute a set of instructions to correct the discrepancy. This will then allow the content-diff to proceed correctly.