### PR TITLE
Moves files out of those custom S3 integration subfolders in uploads

### DIFF
--- a/src/Migrator/General/S3UploadsMigrator.php
+++ b/src/Migrator/General/S3UploadsMigrator.php
@@ -371,6 +371,7 @@ class S3UploadsMigrator implements InterfaceMigrator {
 		$time_start = microtime( true );
 
 		$log_filename = 's3_subfoldersRemove.log';
+		$log_errors_filename = 's3_subfoldersRemove_errors.log';
 
 		$uploads_dir = wp_get_upload_dir()['basedir'] ?? null;
 		if ( is_null( $uploads_dir ) ) {
@@ -431,7 +432,7 @@ class S3UploadsMigrator implements InterfaceMigrator {
 						$new_file = $mm_full_path . '/' . $subdir_file;
 						$renamed  = rename( $old_file, $new_file );
 						if ( false === $renamed ) {
-							$this->log( 'ccp_subfoldersMoveError', $old_file . ' ' . $new_file );
+							$this->log( $log_errors_filename, $old_file . ' ' . $new_file );
 						}
 					}
 				}


### PR DESCRIPTION
Some S3 integration plugins use custom subfolders for images, e.g. 
```
uploads/YYYY/MM/CUSTOM_SUBFOLDER/img.jpg.
```

This commands moves the files down a level to 
```
uploads/YYYY/MM/img.jpg
```

This is refactored from [CharlestonCityPaperMigrator](https://github.com/Automattic/newspack-custom-content-migrator/blob/master/src/Migrator/PublisherSpecific/CharlestonCityPaperMigrator.php#L82) from a year ago, and is an initial commit for the command.

Future improvements:
- the command only moves the files out of the subfolders down a level below into the MM folder, but keeps the custom subfolders -- those can be deleted after the move