### PR TITLE
Catch and fix insert error on collation fix

### DIFF
--- a/src/MigrationLogic/ContentDiffMigrator.php
+++ b/src/MigrationLogic/ContentDiffMigrator.php
@@ -1558,10 +1558,10 @@ class ContentDiffMigrator {
 			$insert_sql = "INSERT INTO `{$source_table}`({$table_columns}) SELECT * FROM {$backup_table} LIMIT {$limiter['start']}, {$limiter['limit']}";
 			$insert_result = $this->wpdb->query( $insert_sql );
 
-			if ( ! is_wp_error( $insert_result ) ) {
+			if ( ! is_wp_error( $insert_result ) && ( false !== $insert_result ) && ( 0 !== $insert_result ) ) {
 				$limiter['start'] = $limiter['start'] + $limiter['limit'];
 			} else {
-				throw new \RuntimeException( "Got up to (not including) {$limiter['start']}" );
+				throw new \RuntimeException( sprintf( "Got up to (not including) %s. Failed running SQL '%s'.", $limiter['start'], $insert_sql ) );
 			}
 
 			if ( $sleep_in_seconds ) {

--- a/src/MigrationLogic/ContentDiffMigrator.php
+++ b/src/MigrationLogic/ContentDiffMigrator.php
@@ -1555,7 +1555,7 @@ class ContentDiffMigrator {
 		$iterations = ceil( $count->counter / $limiter['limit'] );
 		for ( $i = 1; $i <= $iterations; $i++ ) {
 			WP_CLI::log( "Iteration $i out of $iterations" );
-			$insert_sql = "INSERT INTO `{$source_table}`({$table_columns}) SELECT * FROM {$backup_table} LIMIT {$limiter['start']}, {$limiter['limit']}";
+			$insert_sql = "INSERT INTO `{$source_table}`({$table_columns}) SELECT {$table_columns} FROM {$backup_table} LIMIT {$limiter['start']}, {$limiter['limit']}";
 			$insert_result = $this->wpdb->query( $insert_sql );
 
 			if ( ! is_wp_error( $insert_result ) && ( false !== $insert_result ) && ( 0 !== $insert_result ) ) {


### PR DESCRIPTION
There is an error in our new fix collation command when fixing live tables' collations in case where the source table has a different number of columns from the destination table.

Here's a screenshot I got after running the command, it shows no errors, and looks like everything worked well:
![image](https://user-images.githubusercontent.com/29167323/187398972-32c2ed5c-2db8-4470-aac4-c3faabf24d9a.png)

But the `live_wp_users` did not get any of the users inserted, while the`bkp_live_wp_users` had 66 users.

Firstly I added [this error handling](https://github.com/Automattic/newspack-custom-content-migrator/pull/198/files#diff-318440e2d6c2a49e7dc183f0e2590ace80e9984dff1602b43286cfc85eca0133R1561) which checks the return from the insert statement in more details. The return in this example was false, and `! is_wp_error` didn't catch it. I added the SQL which failed to the exception message, too, for convenience:
![image](https://user-images.githubusercontent.com/29167323/187399407-55333942-9b7f-4c6c-8ff7-a384c15750e8.png)

... and then I ran this SQL manually, to check where the issue was:
![image](https://user-images.githubusercontent.com/29167323/187399491-ff472824-4819-4790-be55-0a73c41f42f8.png)

Turns out column count doesn't match. Here are the columns for source and destination tables:

![image](https://user-images.githubusercontent.com/29167323/187399638-e756deba-cd64-4bf0-a996-584724810e79.png)

![image](https://user-images.githubusercontent.com/29167323/187399665-0e1cc30d-c844-4d0f-8b10-d18cb926dee3.png)

So [the fix is](https://github.com/Automattic/newspack-custom-content-migrator/pull/198/files#diff-318440e2d6c2a49e7dc183f0e2590ace80e9984dff1602b43286cfc85eca0133R1558) to just SELECT those same explicit columns, not `*` of them.