### PR TITLE
Add command to migrate republished content from meta to paragraphs

### DIFF
--- a/src/Migrator/PublisherSpecific/LkldNowMigrator.php
+++ b/src/Migrator/PublisherSpecific/LkldNowMigrator.php
@@ -5,6 +5,7 @@ namespace NewspackCustomContentMigrator\Migrator\PublisherSpecific;
 use \NewspackCustomContentMigrator\Migrator\InterfaceMigrator;
 use Simple_Local_Avatars;
 use \WP_CLI;
+use WP_Query;
 
 /**
  * Custom migration scripts for LkldNow.
@@ -57,6 +58,14 @@ class LkldNowMigrator implements InterfaceMigrator {
 			[ $this, 'cmd_lkldnow_migrate_avatars' ],
 			[
 				'shortdesc' => 'Migrates the users\' avatars from WP User Avatars to Simple Local Avatars.',
+				'synopsis'  => [],
+			]
+		);
+		WP_CLI::add_command(
+			'newspack-content-migrator lkldnow-migrate-republished-content',
+			[ $this, 'cmd_lkldnow_republished_content' ],
+			[
+				'shortdesc' => 'Append a hyperlink to the original article to the end of the article.',
 				'synopsis'  => [],
 			]
 		);
@@ -162,6 +171,95 @@ class LkldNowMigrator implements InterfaceMigrator {
 		WP_CLI::success( 'All avatars were migrated and the old metadata was deleted.' );
 	}
 
+	public function cmd_lkldnow_republished_content( $args, $assoc_args ) {
+		$dry_run = isset( $assoc_args['dry-run'] ) ? true : false;
+
+		// Define constants
+
+		$log_filename = 'lkld_updated_articles.log';
+
+		$already_updated_meta_key = '_newspack_original_content_appended';
+
+		$source_link_meta_key = 'aalink';
+		$source_name_meta_key = 'aaname';
+
+		$paragraph_template = '
+		
+		<!-- wp:paragraph -->
+		<p>Source: <a href="%s" target="_blank" rel="noreferrer noopener">%s</a></p>
+		<!-- /wp:paragraph -->';
+		
+		$args = array(
+			'meta_query' => array(
+				array(
+					'key' => 'aalink',
+					'compare' => 'EXISTS',
+				),
+				array(
+					'key' => $already_updated_meta_key,
+					'compare' => 'NOT EXISTS',
+				),
+			),
+			'nopaging' => true,
+		);
+
+		$query = new WP_Query( $args );
+
+		$updated_posts_count = 0;
+
+		foreach ( $query->posts as $index => $post ) {
+			if ( ( $index  + 1 ) % 100 == 0 ) {
+				WP_CLI::log( 'Sleeping for 1 second... ');
+				sleep( 1 );
+			}
+
+			WP_CLI::log( sprintf( 'Updating post #%d', $post->ID ) );
+			
+			$source_link = get_post_meta( $post->ID, $source_link_meta_key, true );
+			$source_name = get_post_meta( $post->ID, $source_name_meta_key, true );
+
+			// Skip if both metas are empty
+			if ( empty( $source_link ) ) {
+				WP_CLI::log( 'The link meta value is empty. Skipping... ');
+				continue;
+			}
+
+			// If the link name is empty, use the URL
+			if ( empty( $source_name ) ) {
+				$source_name = $source_link;
+			}
+
+			// Escape the values and add them to the paragraph temaplte
+
+			$formatted_paragraph = sprintf(
+				$paragraph_template,
+				esc_url( $source_link ),
+				esc_html( $source_name ),
+			);
+
+			$new_post_content = $post->post_content . $formatted_paragraph;	
+
+			$this->log( $log_filename, sprintf( "New content for post #%d:\n%s", $post->ID, $new_post_content ) );
+
+			if ( ! $dry_run ) {				
+				$result = wp_update_post( array(
+					'ID' => $post->ID,
+					'post_content' => $new_post_content,
+				) );
+
+				if ( is_wp_error( $result ) ) {
+					WP_CLI::warning( sprintf( 'Could not update post #%d', $post->ID ) );
+				} else {
+					update_post_meta( $post->ID, $already_updated_meta_key, true );
+					$updated_posts_count++;
+					WP_CLI::log( sprintf( 'Updated #%d successfully.', $post->ID ) );
+				}
+			}
+		}
+
+		WP_CLI::success( sprintf( 'Done! %d posts were updated.', $updated_posts_count ) );
+	}
+
 	/**
 	 * Create an attachment from a URL
 	 */
@@ -175,5 +273,16 @@ class LkldNowMigrator implements InterfaceMigrator {
 		$attachment_id = wp_insert_attachment( $attachment );
 
 		return $attachment_id;
+	}
+
+	/**
+	 * Simple file logging.
+	 *
+	 * @param string $file    File name or path.
+	 * @param string $message Log message.
+	 */
+	public function log( $file, $message ) {
+		$message .= "\n";
+		file_put_contents( $file, $message, FILE_APPEND );
 	}
 }


### PR DESCRIPTION
I created this command for this [ticket](https://app.asana.com/0/1201792624707312/1202664404571760). All it does is take the original's content link and name from the 'aalink' and 'aaname' custom fields, and add a paragraph to the end of each article with a link to that original article.

I also made the script `sleep` every 100 posts to avoid any issues with the database.