### PR TITLE
Fix avatar meta key

### DIFF
--- a/src/MigrationLogic/SimpleLocalAvatars.php
+++ b/src/MigrationLogic/SimpleLocalAvatars.php
@@ -19,7 +19,7 @@ class SimpleLocalAvatars {
 	 * 
 	 * @var string
 	 */
-	const AVATAR_META_KEY = 'simple_local_avatar_rating';
+	const AVATAR_META_KEY = 'simple_local_avatar';
 
 	/**
 	 * Rating meta key


### PR DESCRIPTION
I added the wrong meta key to the `AVATAR_META_KEY`. Creating this PR to fix it. I will push directly to master since it's a simple typo fix.