### PR TITLE
Add missing function readline

### DIFF
--- a/src/Migrator/General/S3UploadsMigrator.php
+++ b/src/Migrator/General/S3UploadsMigrator.php
@@ -62,6 +62,26 @@ class S3UploadsMigrator implements InterfaceMigrator {
 	 * Constructor.
 	 */
 	private function __construct() {
+
+		// Function \readline() has gone missing from Atomic, so here's it is back.
+		if ( ! function_exists( 'readline' ) ) {
+
+			/**
+			 * Taken from class-wp-cli.php function confirm() and simplified.
+			 * 
+			 * @param string $question   Question to display before the prompt.
+			 * @param array  $assoc_args Skips prompt if 'yes' is provided.
+			 * 
+			 * @return string CLI user input.
+			 */
+			function readline( $question, $assoc_args = [] ) {
+				fwrite( STDOUT, $question );
+				$answer = strtolower( trim( fgets( STDIN ) ) );
+
+				return $answer;
+			}
+
+		}
 	}
 
 	/**


### PR DESCRIPTION
\readline() seems to have gone missing from Atomic recently. This adds it back to this migrator so we can use it.

@abdelmalekkkkk , I'm not a 100% sure if you were researching this same functionality as \readline(), but perhaps we could add this code somewhere more reusable, if it would be of use to other Migrators too.