### PR TITLE
Category moving functionality for Outlier/Detour Detroit

### DIFF
--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -306,8 +306,6 @@ class TaxonomyMigrator implements InterfaceCommand {
 		if ( is_null( $category_data ) || empty( $category_data ) ) {
 			WP_CLI::error( sprintf( 'Category ID %d can not be found.', $category_id ) );
 		}
-
-		// Check parent.
 		if ( $destination_parent_category_id == $category_data['parent'] ) {
 			WP_CLI::error( sprintf( 'Category %s already has parent %s. No changes made.', $category_id, $destination_parent_category_id ) );
 		}

--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -311,7 +311,7 @@ class TaxonomyMigrator implements InterfaceCommand {
 		}
 		if ( '0' != $destination_parent_category_id ) {
 			$destination_parent_category_data = $this->taxonomy_logic->get_categories_data( [ 'term_id' => $destination_parent_category_id ], true );
-			if ( is_null( $destination_parent_category_id ) || empty( $destination_parent_category_id ) ) {
+			if ( empty( $destination_parent_category_data ) ) {
 				WP_CLI::error( sprintf( 'Destination category ID %d can not be found.', $destination_parent_category_id ) );
 			}
 		}
@@ -320,7 +320,7 @@ class TaxonomyMigrator implements InterfaceCommand {
 		$category_tree_data = $this->taxonomy_logic->get_category_tree_data( $category_data );
 
 		// Relocate categories and content to a different parent/location.
-		$replanted_category_tree_data = $this->taxonomy_logic->replant_category_tree( $category_tree_data, $destination_parent_category_data['term_id'] );
+		$replanted_category_tree_data = $this->taxonomy_logic->replant_category_tree( $category_tree_data, $destination_parent_category_id );
 
 		// Delete the original category tree.
 		$this->taxonomy_logic->delete_category_tree( $category_tree_data );

--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -210,19 +210,19 @@ class TaxonomyMigrator implements InterfaceCommand {
 			'newspack-content-migrator replant-category-tree',
 			[ $this, 'cmd_replant_category_tree' ],
 			[
-				'shortdesc' => 'Will take a category tree (any Category, either root category or some child category, together with its child categories) and completely move it to be children of a different parent (either an existing category, or as a root category). Also any content belonging to categories in that tree get updated.',
+				'shortdesc' => 'Will take a category tree (any Category, either root category or some child category, together with its child categories) and completely move it under a different parent. Any content belonging to categories in that tree get updated.',
 				'synopsis'  => [
 					[
 						'type'        => 'assoc',
 						'name'        => 'category-id',
-						'description' => 'The Category which will (together with all children Categories) get replanted to a different root/parent.',
+						'description' => 'Category which together with all its children gets replanted to a different parent category.',
 						'optional'    => false,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
-						'name'        => 'destination-category-id',
-						'description' => 'The new parent category where the category tree will get replanted to. If `0` is given, it will be replanted as a root category with its children.',
+						'name'        => 'destination-parent-category-id',
+						'description' => 'Parent category under which the category tree will be replanted. If `0` is given, category tree will become a root category with its children.',
 						'optional'    => false,
 						'repeating'   => false,
 					],
@@ -240,10 +240,45 @@ class TaxonomyMigrator implements InterfaceCommand {
 	 * @return void
 	 */
 	public function cmd_replant_category_tree( $pos_args, $assoc_args ) {
-		$category_id             = $assoc_args[ 'category-id' ];
-		$destination_category_id = $assoc_args[ 'category-destination-category-id' ];
+		$category_id                    = $assoc_args[ 'category-id' ];
+		$destination_parent_category_id = $assoc_args[ 'destination-parent-category-id' ];
 
-		$this->taxonomy_logic_logic;
+		// $term_id_if_new_or_zero = wp_insert_category(
+		// 	[
+		// 		'cat_name'             => 'bname',
+		// 		'category_description' => 'description',
+		// 		'category_parent'      => 3,
+		// 	]
+		// );
+//
+// return;
+
+		// Get and validate the category parent.
+		$category_data = $this->taxonomy_logic_logic->get_categories_data( [ 'term_id' => $category_id ], true );
+		if ( is_null( $category_data ) || empty( $category_data ) ) {
+			WP_CLI::error( sprintf( "Category ID %d can not be found.", $category_id ) );
+		}
+
+		// Get and validate the destination category parent -- can be '0' if moving the category to be the top parent.
+		if ( '0' != $destination_parent_category_id) {
+			$destination_parent_category_data = $this->taxonomy_logic_logic->get_categories_data( [ 'term_id' => $destination_parent_category_id ], true );
+			if ( is_null( $destination_parent_category_id ) || empty( $destination_parent_category_id ) ) {
+				WP_CLI::error( sprintf( "Destination category ID %d can not be found.", $destination_parent_category_id ) );
+			}
+		}
+
+		// Get category tree.
+		$category_tree_data = $this->taxonomy_logic_logic->get_category_tree_data( $category_data );
+
+		// Relocate to different root category.
+		$replanted_category_tree_data = $this->taxonomy_logic_logic->replant_category_tree( $category_tree_data, $destination_parent_category_data[ 'term_id' ] );
+
+		// Delete the original category tree.
+
+		// Update category count.
+
+return;
+
 	}
 
 	/**

--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -301,7 +301,7 @@ class TaxonomyMigrator implements InterfaceCommand {
 		$category_id                    = $assoc_args['category-id'];
 		$destination_parent_category_id = $assoc_args['destination-parent-category-id'];
 
-		// Get and validate the category parent.
+		// Get and validate category and new parent.
 		$category_data = $this->taxonomy_logic->get_categories_data( [ 'term_id' => $category_id ], true );
 		if ( is_null( $category_data ) || empty( $category_data ) ) {
 			WP_CLI::error( sprintf( 'Category ID %d can not be found.', $category_id ) );

--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -256,7 +256,7 @@ class TaxonomyMigrator implements InterfaceCommand {
 					[
 						'type'        => 'assoc',
 						'name'        => 'destination-parent-category-id',
-						'description' => 'Parent category under which the category tree will be replanted. If `0` is given, category tree will become a root category with its children.',
+						'description' => 'Parent category under which the category tree will be replanted. If `0` is given, category tree will become a root category.',
 						'optional'    => false,
 						'repeating'   => false,
 					],

--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -309,8 +309,6 @@ class TaxonomyMigrator implements InterfaceCommand {
 		if ( $destination_parent_category_id == $category_data['parent'] ) {
 			WP_CLI::error( sprintf( 'Category %s already has parent %s. No changes made.', $category_id, $destination_parent_category_id ) );
 		}
-
-		// Get and validate the destination category parent -- can be '0' if moving the category to be the top parent.
 		if ( '0' != $destination_parent_category_id ) {
 			$destination_parent_category_data = $this->taxonomy_logic->get_categories_data( [ 'term_id' => $destination_parent_category_id ], true );
 			if ( is_null( $destination_parent_category_id ) || empty( $destination_parent_category_id ) ) {

--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -307,6 +307,11 @@ class TaxonomyMigrator implements InterfaceCommand {
 			WP_CLI::error( sprintf( 'Category ID %d can not be found.', $category_id ) );
 		}
 
+		// Check parent.
+		if ( $destination_parent_category_id == $category_data['parent'] ) {
+			WP_CLI::error( sprintf( 'Category %s already has parent %s. No changes made.', $category_id, $destination_parent_category_id ) );
+		}
+
 		// Get and validate the destination category parent -- can be '0' if moving the category to be the top parent.
 		if ( '0' != $destination_parent_category_id ) {
 			$destination_parent_category_data = $this->taxonomy_logic->get_categories_data( [ 'term_id' => $destination_parent_category_id ], true );

--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -4,6 +4,7 @@ namespace NewspackCustomContentMigrator\Command\General;
 
 use \NewspackCustomContentMigrator\Command\InterfaceCommand;
 use \NewspackCustomContentMigrator\Logic\Posts;
+use \NewspackCustomContentMigrator\Logic\Taxonomy as Taxonomy_Logic;
 use stdClass;
 use \WP_CLI;
 
@@ -20,6 +21,13 @@ class TaxonomyMigrator implements InterfaceCommand {
 	private $posts_logic;
 
 	/**
+	 * Taxonomy_Logic class object.
+	 *
+	 * @var Taxonomy_Logic $taxonomy_logic
+	 */
+	private $taxonomy_logic;
+
+	/**
 	 * List of taxonomy values recognized by WordPress.
 	 *
 	 * @var string[] WordPress recognized taxonomies.
@@ -34,7 +42,8 @@ class TaxonomyMigrator implements InterfaceCommand {
 	 * Constructor.
 	 */
 	private function __construct() {
-		$this->posts_logic = new Posts();
+		$this->posts_logic          = new Posts();
+		$this->taxonomy_logic_logic = new Taxonomy_Logic();
 	}
 
 	/**
@@ -196,6 +205,45 @@ class TaxonomyMigrator implements InterfaceCommand {
 				],
 			]
 		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator replant-category-tree',
+			[ $this, 'cmd_replant_category_tree' ],
+			[
+				'shortdesc' => 'Will take a category tree (any Category, either root category or some child category, together with its child categories) and completely move it to be children of a different parent (either an existing category, or as a root category). Also any content belonging to categories in that tree get updated.',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'category-id',
+						'description' => 'The Category which will (together with all children Categories) get replanted to a different root/parent.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'destination-category-id',
+						'description' => 'The new parent category where the category tree will get replanted to. If `0` is given, it will be replanted as a root category with its children.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Callable for `newspack-content-migrator replant-category-tree`.
+	 *
+	 * @param array $pos_args   Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 *
+	 * @return void
+	 */
+	public function cmd_replant_category_tree( $pos_args, $assoc_args ) {
+		$category_id             = $assoc_args[ 'category-id' ];
+		$destination_category_id = $assoc_args[ 'category-destination-category-id' ];
+
+		$this->taxonomy_logic_logic;
 	}
 
 	/**

--- a/src/Logic/Taxonomy.php
+++ b/src/Logic/Taxonomy.php
@@ -12,6 +12,186 @@ namespace NewspackCustomContentMigrator\Logic;
  */
 class Taxonomy {
 
+	/**
+	 * Returns single or multiple Category data arrays depending on $where.
+	 *
+	 * @param array $where               Where columns from $supported_where_columns_and_tables.
+	 * @param bool  $return_first_result If true, will return a one dimensional array which doesn't contain further subarrays.
+	 *
+	 * @return array {
+	 *      Array with Category data subarrays, or if $return_first_result === true just these keys and values without subarray structure.
+	 *
+	 *      @type string term_id     Category term_id.
+	 *      @type string taxonomy    Should always be 'category'.
+	 *      @type string name        Category name.
+	 *      @type string slug        Category slug.
+	 *      @type string parent      Category parent term_id.
+	 *      @type string description Category description.
+	 *      @type string count       Category count.
+	 * }
+	 */
+	public function get_categories_data( array $where, bool $return_first_result = false ): array {
+		if ( empty( $where ) ) {
+			return [];
+		}
 
+		global $wpdb;
+		// Supported where columns and the tables where they can be found.
+		$supported_where_columns_and_tables = [
+			'term_id' => 't',
+			'taxonomy' => 'tt',
+			'name' => 't',
+			'slug' => 't',
+			'parent' => 'tt',
+			'description' => 'tt',
+		];
+
+		// Compose AND clause.
+		$and_clause = '';
+		$and_values = [];
+		foreach ( $where as $where_column => $where_value ) {
+
+			// Check if where column is supported.
+			if ( ! isset( $supported_where_columns_and_tables[ $where_column ] ) ) {
+				throw new \RuntimeException( sprintf( "Where column %s not supported.", $where_column ) );
+			}
+
+			// Compose the AND clause.
+			$where_column_escaped = esc_sql( $where_column );
+			$where_table = $supported_where_columns_and_tables[ $where_column ];
+			$and_clause .= ' AND ' . $where_table . '.' . $where_column_escaped . ' = %s ';
+			$and_values[] = $where_value;
+		}
+
+		// Limit clause.
+		$limit_clause = '';
+		if ( true === $return_first_result ) {
+			$limit_clause = ' LIMIT 1 ';
+		}
+
+		$categories = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT t.term_id, tt.taxonomy, t.name, t.slug, tt.parent, tt.description, tt.count
+				FROM {$wpdb->terms} t
+		        JOIN {$wpdb->term_taxonomy} tt ON t.term_id = tt.term_id
+				WHERE tt.taxonomy = 'category' ".
+				$and_clause .
+				$limit_clause,
+				$and_values
+			),
+			ARRAY_A
+		);
+
+		// Return just the first element.
+		if ( true === $return_first_result ) {
+			return $categories[0] ?? [];
+		}
+
+		return $categories;
+	}
+
+	/**
+	 * Fetches a full category tree with all the children categories down to the end ones.
+	 *
+	 * @param array  $category {
+	 *    Category data array.
+	 *
+	 *     @type string term_id     Category term_id.
+	 *     @type string taxonomy    Should always be 'category'.
+	 *     @type string name        Category name.
+	 *     @type string slug        Category slug.
+	 *     @type string parent      Category parent term_id.
+	 *     @type string description Category description.
+	 *     @type string count       Category count.
+	 * }
+	 *
+	 * @return array {
+	 *     A nested array of subarray categories.
+	 *
+	 *     @type string term_id     Category term_id.
+	 *     @type string taxonomy    Should always be 'category'.
+	 *     @type string name        Category name.
+	 *     @type string slug        Category slug.
+	 *     @type string parent      Parent ID.
+	 *     @type string description Category description.
+	 *     @type string count       Category count.
+	 *     @type array  children    Array with children categories with same keys-values as this array.
+	 * }
+	 */
+	public function get_category_tree_data( array $category ): array {
+		$category_tree = $category;
+		$category_tree[ 'children' ] = [];
+
+		$children_categories = $this->get_categories_data( [ 'parent' => $category[ 'term_id' ] ] );
+		if ( ! empty( $children_categories ) ) {
+			foreach ( $children_categories as $child_category ) {
+				$category_tree[ 'children' ][] = $this->get_category_tree_data( $child_category );
+			}
+		}
+
+		return $category_tree;
+	}
+
+	/**
+	 * Relocates the whole category tree and plants it under a new parent.
+	 *
+	 * @param $category_tree_data
+	 * @param int|array $destination_parent_category_data
+	 *
+	 * @return void
+	 */
+	public function replant_category_tree( $category_tree_data, $parent_term_id ) {
+
+		// TODO TEST parent is 0?
+
+		// Get this category if it already exists.
+		$existing_category_data = $this->get_categories_data( [
+			'name' => $category_tree_data['name'],
+			'description' => $category_tree_data['description'],
+			'parent' => $parent_term_id
+		], true );
+
+		// TODO TEST when $category_recreated_data exists.
+
+		// Create if doesn't exist.
+		if ( ! empty( $existing_category_data ) ) {
+			$replanted_category_term_id = $existing_category_data[ 'term_id' ];
+		} else {
+			// Change this slug to free up the slug, so that the newly created category has a nice version of it.
+			$updated = wp_update_term( $category_tree_data[ 'term_id' ], 'category', [ 'slug' => $category_tree_data[ 'slug' ] . '_x' ] );
+			if ( is_wp_error( $updated ) ) {
+				throw new \RuntimeException( sprintf( "Error when changing category %d slug from %s to %s", $category_tree_data[ 'term_id' ], $category_tree_data[ 'slug' ], $category_tree_data[ 'slug' ] . '_old' ) );
+			}
+
+			// Recreate category.
+			$replanted_category_term_id = $this->create_category( $category_tree_data, $parent_term_id );
+		}
+
+		// Reassign all posts from original category to new category.
+
+		// Recreate children recursively.
+		foreach ( $category_tree_data[ 'children' ] as $category_child_tree_data ) {
+			$this->replant_category_tree( $category_child_tree_data, $replanted_category_term_id );
+
+			// Reassign all posts from original child category to new child category.
+		}
+
+		$d = 1;
+
+	}
+
+	public function create_category( $category_tree_data, $parent_term_id ) {
+
+		// \wp_insert_category() returns created term_id, or zero if the category exists.
+		$term_id_if_new_or_zero = wp_insert_category(
+			[
+				'cat_name'             => $category_tree_data['name'],
+				'category_description' => $category_tree_data['description'],
+				'category_parent'      => $parent_term_id,
+			]
+		);
+
+		return $term_id_if_new_or_zero;
+	}
 
 }

--- a/src/Logic/Taxonomy.php
+++ b/src/Logic/Taxonomy.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Logic for working Taxonomies.
+ *
+ * @package NewspackCustomContentMigrator
+ */
+
+namespace NewspackCustomContentMigrator\Logic;
+
+/**
+ * Taxonomy implements common migration logic that are used to work with the Simple Local Avatars plugin
+ */
+class Taxonomy {
+
+
+
+}

--- a/src/Logic/Taxonomy.php
+++ b/src/Logic/Taxonomy.php
@@ -162,8 +162,6 @@ class Taxonomy {
 	 */
 	public function replant_category_tree( $category_tree_data, $parent_term_id ) {
 
-		// TODO TEST parent is 0?
-
 		// Get this category if it already exists.
 		$existing_category_data = $this->get_categories_data(
 			[

--- a/src/Logic/Taxonomy.php
+++ b/src/Logic/Taxonomy.php
@@ -15,187 +15,6 @@ use WP_CLI;
 class Taxonomy {
 
 	/**
-	 * Returns single or multiple Category data arrays depending on $where.
-	 *
-	 * @param array $where               Where columns from $supported_where_columns_and_tables.
-	 * @param bool  $return_first_result If true, will return a one dimensional array which doesn't contain further subarrays.
-	 *
-	 * @throws \RuntimeException If wrong $where key is given.
-	 *
-	 * @return array {
-	 *      Array with Category data subarrays, or if $return_first_result === true just these keys and values without subarray structure.
-	 *
-	 *      @type string term_id     Category term_id.
-	 *      @type string taxonomy    Should always be 'category'.
-	 *      @type string name        Category name.
-	 *      @type string slug        Category slug.
-	 *      @type string parent      Category parent term_id.
-	 *      @type string description Category description.
-	 *      @type string count       Category count.
-	 * }
-	 */
-	public function get_categories_data( array $where, bool $return_first_result = false ): array {
-		if ( empty( $where ) ) {
-			return [];
-		}
-
-		global $wpdb;
-
-		// Supported $where keys and the tables of these columns in DB.
-		$supported_where_columns_and_tables = [
-			'term_id'     => 't',
-			'taxonomy'    => 'tt',
-			'name'        => 't',
-			'slug'        => 't',
-			'parent'      => 'tt',
-			'description' => 'tt',
-		];
-
-		// Compose the AND clause.
-		$and_clause = '';
-		$and_values = [];
-		foreach ( $where as $where_column => $where_value ) {
-
-			// Check if where column is supported.
-			if ( ! isset( $supported_where_columns_and_tables[ $where_column ] ) ) {
-				throw new \RuntimeException( sprintf( 'Where column %s not supported.', $where_column ) );
-			}
-
-			// Compose the AND clause.
-			$where_column_escaped = esc_sql( $where_column );
-			$where_table          = $supported_where_columns_and_tables[ $where_column ];
-			$and_clause          .= ' AND ' . $where_table . '.' . $where_column_escaped . ' = %s ';
-			$and_values[]         = $where_value;
-		}
-
-		// Limit clause.
-		$limit_clause = '';
-		if ( true === $return_first_result ) {
-			$limit_clause = ' LIMIT 1 ';
-		}
-
-		// phpcs:disable -- $and_clause and $limit_clause are sanitized.
-		$categories = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT t.term_id, tt.taxonomy, t.name, t.slug, tt.parent, tt.description, tt.count
-				FROM {$wpdb->terms} t
-		        JOIN {$wpdb->term_taxonomy} tt ON t.term_id = tt.term_id
-				WHERE tt.taxonomy = 'category' " .
-				$and_clause .
-				$limit_clause,
-				$and_values
-			),
-			ARRAY_A
-		);
-		// phpcs:enable
-
-		// Return just the first element.
-		if ( true === $return_first_result ) {
-			return $categories[0] ?? [];
-		}
-
-		return $categories;
-	}
-
-	/**
-	 * Fetches a full category tree with all the children categories down to the end ones.
-	 *
-	 * @param array $category {
-	 *   Category data array.
-	 *
-	 *     @type string term_id     Category term_id.
-	 *     @type string taxonomy    Should always be 'category'.
-	 *     @type string name        Category name.
-	 *     @type string slug        Category slug.
-	 *     @type string parent      Category parent term_id.
-	 *     @type string description Category description.
-	 *     @type string count       Category count.
-	 * }
-	 *
-	 * @return array {
-	 *     A nested array of subarray categories.
-	 *
-	 *     @type string term_id     Category term_id.
-	 *     @type string taxonomy    Should always be 'category'.
-	 *     @type string name        Category name.
-	 *     @type string slug        Category slug.
-	 *     @type string parent      Parent ID.
-	 *     @type string description Category description.
-	 *     @type string count       Category count.
-	 *     @type array  children    Array with children categories with same keys-values as this array.
-	 * }
-	 */
-	public function get_category_tree_data( array $category ): array {
-		$category_tree             = $category;
-		$category_tree['children'] = [];
-
-		$children_categories = $this->get_categories_data( [ 'parent' => $category['term_id'] ] );
-		if ( ! empty( $children_categories ) ) {
-			foreach ( $children_categories as $child_category ) {
-				$category_tree['children'][] = $this->get_category_tree_data( $child_category );
-			}
-		}
-
-		return $category_tree;
-	}
-
-	/**
-	 * Uproots and permanently relocates the whole category tree under a new parent.
-	 *
-	 * @param array $category_tree_data {
-	 *     A nested array of subarray categories, same as the return of self::get_category_tree_data().
-	 *
-	 *     @type string term_id     Category term_id.
-	 *     @type string taxonomy    Should always be 'category'.
-	 *     @type string name        Category name.
-	 *     @type string slug        Category slug.
-	 *     @type string parent      Parent ID.
-	 *     @type string description Category description.
-	 *     @type string count       Category count.
-	 *     @type array  children    Array with children categories with same keys-values as this array.
-	 * }
-	 * @param int   $parent_term_id Parent term_id.
-	 *
-	 * @throws \RuntimeException If a category slug was not updated successfully.
-	 *
-	 * @return void
-	 */
-	public function replant_category_tree( $category_tree_data, $parent_term_id ) {
-
-		// Get this category if it already exists.
-		$existing_category_data = $this->get_categories_data(
-			[
-				'name'        => $category_tree_data['name'],
-				'description' => $category_tree_data['description'],
-				'parent'      => $parent_term_id,
-			],
-			true
-		);
-
-		// Create if doesn't exist.
-		if ( ! empty( $existing_category_data ) ) {
-			$replanted_category_term_id = $existing_category_data['term_id'];
-		} else {
-			// Change this slug to free up the slug, so that the newly created category has a nice version of it.
-			$updated = wp_update_term( $category_tree_data['term_id'], 'category', [ 'slug' => $category_tree_data['slug'] . '_x' ] );
-			if ( is_wp_error( $updated ) ) {
-				throw new \RuntimeException( sprintf( 'Error when changing category %d slug from %s to %s', $category_tree_data['term_id'], $category_tree_data['slug'], $category_tree_data['slug'] . '_old' ) );
-			}
-
-			// Recreate category.
-			$replanted_category_term_id = $this->create_category( $category_tree_data, $parent_term_id );
-		}
-
-		// Reassign all posts from original category to new category.
-		$this->reassign_all_content_from_one_category_to_another( $category_tree_data['term_id'], $replanted_category_term_id );
-
-		// Replant children categories recursively.
-		foreach ( $category_tree_data['children'] as $category_child_tree_data ) {
-			$this->replant_category_tree( $category_child_tree_data, $replanted_category_term_id );
-		}
-	}
-
-	/**
 	 * Fixes counts for taxonomy.
 	 *
 	 * @param string $taxonomy Taxonomy, e.g. 'category'.
@@ -218,33 +37,6 @@ class Taxonomy {
 	}
 
 	/**
-	 * Deletes the category together with all its children categories.
-	 *
-	 * @param array $category_tree_data {
-	 *     A nested array of subarray categories, same as the return of self::get_category_tree_data().
-	 *
-	 *     @type string term_id     Category term_id.
-	 *     @type string taxonomy    Should always be 'category'.
-	 *     @type string name        Category name.
-	 *     @type string slug        Category slug.
-	 *     @type string parent      Parent ID.
-	 *     @type string description Category description.
-	 *     @type string count       Category count.
-	 *     @type array  children    Array with children categories with same keys-values as this array.
-	 * }
-	 *
-	 * @return void
-	 */
-	public function delete_category_tree( array $category_tree_data ): void {
-
-		wp_delete_category( $category_tree_data['term_id'] );
-
-		foreach ( $category_tree_data['children'] as $child_category_tree_data ) {
-			$this->delete_category_tree( $child_category_tree_data );
-		}
-	}
-
-	/**
 	 * Reassigns all content from one category to a different category.
 	 *
 	 * @param int $source_term_id      Source term_id.
@@ -257,6 +49,8 @@ class Taxonomy {
 		$destination_term_taxonomy_id = $this->get_term_taxonomy_id_by_term_id( $destination_term_id );
 
 		$this->update_object_relational_mapping_term_taxonomy_id( $source_term_taxonomy_id, $destination_term_taxonomy_id );
+
+		$this->fix_taxonomy_term_counts( 'category' );
 	}
 
 	/**
@@ -284,38 +78,5 @@ class Taxonomy {
 		global $wpdb;
 
 		return $wpdb->get_var( $wpdb->prepare( "UPDATE {$wpdb->term_relationships} SET term_taxonomy_id = %d WHERE term_taxonomy_id = %d ;", $new_term_taxonomy_id, $old_term_taxonomy_id ) );
-	}
-
-	/**
-	 * Creates the given category (but not its children) under a given parent ID.
-	 *
-	 * @param array $category_tree_data {
-	 *     A nested array of subarray categories, same as the return of self::get_category_tree_data().
-	 *
-	 *     @type string term_id     Category term_id.
-	 *     @type string taxonomy    Should always be 'category'.
-	 *     @type string name        Category name.
-	 *     @type string slug        Category slug.
-	 *     @type string parent      Parent ID.
-	 *     @type string description Category description.
-	 *     @type string count       Category count.
-	 *     @type array  children    Array with children categories with same keys-values as this array.
-	 * }
-	 * @param int   $parent_term_id     Parent ID under which the category is created.
-	 *
-	 * @return int|\WP_Error Return from \wp_insert_category().
-	 */
-	public function create_category( $category_tree_data, $parent_term_id ) {
-
-		// \wp_insert_category() returns created term_id, or zero if the category exists.
-		$term_id_if_new_or_zero = wp_insert_category(
-			[
-				'cat_name'             => $category_tree_data['name'],
-				'category_description' => $category_tree_data['description'],
-				'category_parent'      => $parent_term_id,
-			]
-		);
-
-		return $term_id_if_new_or_zero;
 	}
 }

--- a/src/Logic/Taxonomy.php
+++ b/src/Logic/Taxonomy.php
@@ -20,6 +20,8 @@ class Taxonomy {
 	 * @param array $where               Where columns from $supported_where_columns_and_tables.
 	 * @param bool  $return_first_result If true, will return a one dimensional array which doesn't contain further subarrays.
 	 *
+	 * @throws \RuntimeException If wrong $where key is given.
+	 *
 	 * @return array {
 	 *      Array with Category data subarrays, or if $return_first_result === true just these keys and values without subarray structure.
 	 *
@@ -38,31 +40,32 @@ class Taxonomy {
 		}
 
 		global $wpdb;
-		// Supported where columns and the tables where they can be found.
+
+		// Supported $where keys and the tables of these columns in DB.
 		$supported_where_columns_and_tables = [
-			'term_id' => 't',
-			'taxonomy' => 'tt',
-			'name' => 't',
-			'slug' => 't',
-			'parent' => 'tt',
+			'term_id'     => 't',
+			'taxonomy'    => 'tt',
+			'name'        => 't',
+			'slug'        => 't',
+			'parent'      => 'tt',
 			'description' => 'tt',
 		];
 
-		// Compose AND clause.
+		// Compose the AND clause.
 		$and_clause = '';
 		$and_values = [];
 		foreach ( $where as $where_column => $where_value ) {
 
 			// Check if where column is supported.
 			if ( ! isset( $supported_where_columns_and_tables[ $where_column ] ) ) {
-				throw new \RuntimeException( sprintf( "Where column %s not supported.", $where_column ) );
+				throw new \RuntimeException( sprintf( 'Where column %s not supported.', $where_column ) );
 			}
 
 			// Compose the AND clause.
 			$where_column_escaped = esc_sql( $where_column );
-			$where_table = $supported_where_columns_and_tables[ $where_column ];
-			$and_clause .= ' AND ' . $where_table . '.' . $where_column_escaped . ' = %s ';
-			$and_values[] = $where_value;
+			$where_table          = $supported_where_columns_and_tables[ $where_column ];
+			$and_clause          .= ' AND ' . $where_table . '.' . $where_column_escaped . ' = %s ';
+			$and_values[]         = $where_value;
 		}
 
 		// Limit clause.
@@ -71,18 +74,20 @@ class Taxonomy {
 			$limit_clause = ' LIMIT 1 ';
 		}
 
+		// phpcs:disable -- $and_clause and $limit_clause are sanitized.
 		$categories = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT t.term_id, tt.taxonomy, t.name, t.slug, tt.parent, tt.description, tt.count
 				FROM {$wpdb->terms} t
 		        JOIN {$wpdb->term_taxonomy} tt ON t.term_id = tt.term_id
-				WHERE tt.taxonomy = 'category' ".
+				WHERE tt.taxonomy = 'category' " .
 				$and_clause .
 				$limit_clause,
 				$and_values
 			),
 			ARRAY_A
 		);
+		// phpcs:enable
 
 		// Return just the first element.
 		if ( true === $return_first_result ) {
@@ -95,8 +100,8 @@ class Taxonomy {
 	/**
 	 * Fetches a full category tree with all the children categories down to the end ones.
 	 *
-	 * @param array  $category {
-	 *    Category data array.
+	 * @param array $category {
+	 *   Category data array.
 	 *
 	 *     @type string term_id     Category term_id.
 	 *     @type string taxonomy    Should always be 'category'.
@@ -121,13 +126,13 @@ class Taxonomy {
 	 * }
 	 */
 	public function get_category_tree_data( array $category ): array {
-		$category_tree = $category;
-		$category_tree[ 'children' ] = [];
+		$category_tree             = $category;
+		$category_tree['children'] = [];
 
-		$children_categories = $this->get_categories_data( [ 'parent' => $category[ 'term_id' ] ] );
+		$children_categories = $this->get_categories_data( [ 'parent' => $category['term_id'] ] );
 		if ( ! empty( $children_categories ) ) {
 			foreach ( $children_categories as $child_category ) {
-				$category_tree[ 'children' ][] = $this->get_category_tree_data( $child_category );
+				$category_tree['children'][] = $this->get_category_tree_data( $child_category );
 			}
 		}
 
@@ -137,8 +142,21 @@ class Taxonomy {
 	/**
 	 * Uproots and permanently relocates the whole category tree under a new parent.
 	 *
-	 * @param $category_tree_data
-	 * @param int|array $destination_parent_category_data
+	 * @param array $category_tree_data {
+	 *     A nested array of subarray categories, same as the return of self::get_category_tree_data().
+	 *
+	 *     @type string term_id     Category term_id.
+	 *     @type string taxonomy    Should always be 'category'.
+	 *     @type string name        Category name.
+	 *     @type string slug        Category slug.
+	 *     @type string parent      Parent ID.
+	 *     @type string description Category description.
+	 *     @type string count       Category count.
+	 *     @type array  children    Array with children categories with same keys-values as this array.
+	 * }
+	 * @param int   $parent_term_id Parent term_id.
+	 *
+	 * @throws \RuntimeException If a category slug was not updated successfully.
 	 *
 	 * @return void
 	 */
@@ -147,20 +165,23 @@ class Taxonomy {
 		// TODO TEST parent is 0?
 
 		// Get this category if it already exists.
-		$existing_category_data = $this->get_categories_data( [
-			'name' => $category_tree_data['name'],
-			'description' => $category_tree_data['description'],
-			'parent' => $parent_term_id
-		], true );
+		$existing_category_data = $this->get_categories_data(
+			[
+				'name'        => $category_tree_data['name'],
+				'description' => $category_tree_data['description'],
+				'parent'      => $parent_term_id,
+			],
+			true
+		);
 
 		// Create if doesn't exist.
 		if ( ! empty( $existing_category_data ) ) {
-			$replanted_category_term_id = $existing_category_data[ 'term_id' ];
+			$replanted_category_term_id = $existing_category_data['term_id'];
 		} else {
 			// Change this slug to free up the slug, so that the newly created category has a nice version of it.
-			$updated = wp_update_term( $category_tree_data[ 'term_id' ], 'category', [ 'slug' => $category_tree_data[ 'slug' ] . '_x' ] );
+			$updated = wp_update_term( $category_tree_data['term_id'], 'category', [ 'slug' => $category_tree_data['slug'] . '_x' ] );
 			if ( is_wp_error( $updated ) ) {
-				throw new \RuntimeException( sprintf( "Error when changing category %d slug from %s to %s", $category_tree_data[ 'term_id' ], $category_tree_data[ 'slug' ], $category_tree_data[ 'slug' ] . '_old' ) );
+				throw new \RuntimeException( sprintf( 'Error when changing category %d slug from %s to %s', $category_tree_data['term_id'], $category_tree_data['slug'], $category_tree_data['slug'] . '_old' ) );
 			}
 
 			// Recreate category.
@@ -168,10 +189,10 @@ class Taxonomy {
 		}
 
 		// Reassign all posts from original category to new category.
-		$this->reassign_all_content_from_one_category_to_another( $category_tree_data[ 'term_id' ], $replanted_category_term_id );
+		$this->reassign_all_content_from_one_category_to_another( $category_tree_data['term_id'], $replanted_category_term_id );
 
 		// Replant children categories recursively.
-		foreach ( $category_tree_data[ 'children' ] as $category_child_tree_data ) {
+		foreach ( $category_tree_data['children'] as $category_child_tree_data ) {
 			$this->replant_category_tree( $category_child_tree_data, $replanted_category_term_id );
 		}
 	}
@@ -198,15 +219,41 @@ class Taxonomy {
 		wp_cache_flush();
 	}
 
+	/**
+	 * Deletes the category together with all its children categories.
+	 *
+	 * @param array $category_tree_data {
+	 *     A nested array of subarray categories, same as the return of self::get_category_tree_data().
+	 *
+	 *     @type string term_id     Category term_id.
+	 *     @type string taxonomy    Should always be 'category'.
+	 *     @type string name        Category name.
+	 *     @type string slug        Category slug.
+	 *     @type string parent      Parent ID.
+	 *     @type string description Category description.
+	 *     @type string count       Category count.
+	 *     @type array  children    Array with children categories with same keys-values as this array.
+	 * }
+	 *
+	 * @return void
+	 */
 	public function delete_category_tree( array $category_tree_data ): void {
 
-		$d = wp_delete_category($category_tree_data['term_id']);
+		wp_delete_category( $category_tree_data['term_id'] );
 
-		foreach ( $category_tree_data[ 'children' ] as $child_category_tree_data ) {
-			$this->delete_category_tree($child_category_tree_data);
+		foreach ( $category_tree_data['children'] as $child_category_tree_data ) {
+			$this->delete_category_tree( $child_category_tree_data );
 		}
 	}
 
+	/**
+	 * Reassigns all content from one category to a different category.
+	 *
+	 * @param int $source_term_id      Source term_id.
+	 * @param int $destination_term_id Destination term_id.
+	 *
+	 * @return void
+	 */
 	public function reassign_all_content_from_one_category_to_another( int $source_term_id, int $destination_term_id ): void {
 		$source_term_taxonomy_id      = $this->get_term_taxonomy_id_by_term_id( $source_term_id );
 		$destination_term_taxonomy_id = $this->get_term_taxonomy_id_by_term_id( $destination_term_id );
@@ -214,18 +261,52 @@ class Taxonomy {
 		$this->update_object_relational_mapping_term_taxonomy_id( $source_term_taxonomy_id, $destination_term_taxonomy_id );
 	}
 
+	/**
+	 * Gets term_taxonomy_id of a term_id.
+	 *
+	 * @param int $term_id Term_id.
+	 *
+	 * @return string|null Return from $wpdb::get_var().
+	 */
 	public function get_term_taxonomy_id_by_term_id( $term_id ) {
 		global $wpdb;
 
 		return $wpdb->get_var( $wpdb->prepare( "SELECT term_taxonomy_id FROM {$wpdb->term_taxonomy} WHERE term_id = %d;", $term_id ) );
 	}
 
+	/**
+	 * Runs a direct DB UPDATE on wp_term_relationships table and updates term_taxonomy_id from one value to a different one.
+	 *
+	 * @param int $old_term_taxonomy_id Old term_taxonomy_id.
+	 * @param int $new_term_taxonomy_id New term_taxonomy_id.
+	 *
+	 * @return string|null Return from $wpdb::get_var().
+	 */
 	public function update_object_relational_mapping_term_taxonomy_id( $old_term_taxonomy_id, $new_term_taxonomy_id ) {
 		global $wpdb;
 
 		return $wpdb->get_var( $wpdb->prepare( "UPDATE {$wpdb->term_relationships} SET term_taxonomy_id = %d WHERE term_taxonomy_id = %d ;", $new_term_taxonomy_id, $old_term_taxonomy_id ) );
 	}
 
+	/**
+	 * Creates the given category (but not its children) under a given parent ID.
+	 *
+	 * @param array $category_tree_data {
+	 *     A nested array of subarray categories, same as the return of self::get_category_tree_data().
+	 *
+	 *     @type string term_id     Category term_id.
+	 *     @type string taxonomy    Should always be 'category'.
+	 *     @type string name        Category name.
+	 *     @type string slug        Category slug.
+	 *     @type string parent      Parent ID.
+	 *     @type string description Category description.
+	 *     @type string count       Category count.
+	 *     @type array  children    Array with children categories with same keys-values as this array.
+	 * }
+	 * @param int   $parent_term_id     Parent ID under which the category is created.
+	 *
+	 * @return int|\WP_Error Return from \wp_insert_category().
+	 */
 	public function create_category( $category_tree_data, $parent_term_id ) {
 
 		// \wp_insert_category() returns created term_id, or zero if the category exists.


### PR DESCRIPTION
#### Command `newspack-content-migrator replant-category-tree`

Can take any category tree (parent category and all the children categories), and relocate/replant that category tree under a different parent.

Before:
![image](https://user-images.githubusercontent.com/29167323/209664895-82348b4a-b335-4e75-82b0-4200ff02926e.png)

After:
![image](https://user-images.githubusercontent.com/29167323/209664912-bd6d580c-1777-481b-8e4e-87d19b067147.png)

#### Command `newspack-content-migrator move-content-from-one-category-to-another`

As the title says, moves all the posts from one category to a different one.
