### PR TITLE
Fix for Deprecated notice in WooCommOrdersAndSubscriptionsMigrator.php

### DIFF
--- a/src/Command/General/WooCommOrdersAndSubscriptionsMigrator.php
+++ b/src/Command/General/WooCommOrdersAndSubscriptionsMigrator.php
@@ -149,7 +149,7 @@ class WooCommOrdersAndSubscriptionsMigrator implements InterfaceCommand {
 	 * @param string   $table_prefix_source
 	 * @param string   $table_prefix_destination
 	 */
-	private function migrate_order_or_subscription( $source_order_id = null, $source_subscription_id = null, $table_prefix_source, $table_prefix_destination ) {
+	private function migrate_order_or_subscription( $source_order_id = null, $source_subscription_id = null, $table_prefix_source = '', $table_prefix_destination = '' ) {
 		global $wpdb;
 
 		if ( is_null( $source_order_id ) && is_null( $source_subscription_id ) ) {


### PR DESCRIPTION
The following deprecated notice appears several times when running commands in the migrator:

> PHP Deprecated:  Required parameter $table_prefix_source follows optional parameter $source_order_id in /var/www/html/wp-content/plugins/newspack-custom-content-migrator/src/Command/General/WooCommOrdersAndSubscriptionsMigrator.php on line 152

This change adds default values to the last two parameters of the `migrate_order_or_subscription()` function in order to satisfy the requirement in later versions of PHP.