### PR TITLE
Add/saporta report migrator

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -77,5 +77,6 @@ PluginSetup::register_migrators(
 		Command\PublisherSpecific\BillyPennMigrator::class,
 		Command\PublisherSpecific\IndyWeekMigrator::class,
 		Command\PublisherSpecific\Moco360Migrator::class,
+		Command\PublisherSpecific\SaportaReportMigrator::class,
 	)
 );

--- a/src/Command/PublisherSpecific/SaportaReportMigrator.php
+++ b/src/Command/PublisherSpecific/SaportaReportMigrator.php
@@ -106,7 +106,8 @@ class SaportaReportMigrator implements InterfaceCommand {
 
 		$meta_query = [
 			[
-				'key'     => '_newspack_migration_gallery_migrated',
+				// 'key'     => '_newspack_migration_gallery_migrated',
+				'key'     => '_newspack_migration_gallery_migrated_',
 				'compare' => 'NOT EXISTS',
 			],
 		];
@@ -174,7 +175,7 @@ class SaportaReportMigrator implements InterfaceCommand {
 				}
 			}
 
-			update_post_meta( $post->ID, '_newspack_migration_gallery_migrated', true );
+			update_post_meta( $post->ID, '_newspack_migration_gallery_migrated_', true );
 		}
 	}
 }

--- a/src/Command/PublisherSpecific/SaportaReportMigrator.php
+++ b/src/Command/PublisherSpecific/SaportaReportMigrator.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Command\PublisherSpecific;
+
+use \WP_CLI;
+use \NewspackCustomContentMigrator\Command\InterfaceCommand;
+use NewspackCustomContentMigrator\Logic\CoAuthorPlus as CoAuthorPlusLogic;
+use \NewspackContentConverter\ContentPatcher\ElementManipulators\SquareBracketsElementManipulator;
+use \NewspackCustomContentMigrator\Logic\GutenbergBlockGenerator;
+use \NewspackCustomContentMigrator\Utils\Logger;
+
+/**
+ * Custom migration scripts for Saporta News.
+ */
+class SaportaReportMigrator implements InterfaceCommand {
+	const GALLERIES_MIGRATOR_LOG = 'saporta_report_galleries_migrator.log';
+
+	/**
+	 * @var null|InterfaceCommand Instance.
+	 */
+	private static $instance = null;
+
+	/**
+	 * @var null|CoAuthorPlusLogic.
+	 */
+	private $coauthorsplus_logic;
+
+	/**
+	 * @var SquareBracketsElementManipulator.
+	 */
+	private $squarebracketselement_manipulator;
+
+	/**
+	 * @var GutenbergBlockGenerator.
+	 */
+	private $gutenberg_block_generator;
+
+	/**
+	 * @var Logger.
+	 */
+	private $logger;
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->coauthorsplus_logic               = new CoAuthorPlusLogic();
+		$this->squarebracketselement_manipulator = new SquareBracketsElementManipulator();
+		$this->gutenberg_block_generator         = new GutenbergBlockGenerator();
+		$this->logger                            = new Logger();
+	}
+
+	/**
+	 * Singleton get_instance().
+	 *
+	 * @return InterfaceCommand|null
+	 */
+	public static function get_instance() {
+		$class = get_called_class();
+		if ( null === self::$instance ) {
+			self::$instance = new $class();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * See InterfaceCommand::register_commands.
+	 */
+	public function register_commands() {
+		WP_CLI::add_command(
+			'newspack-content-migrator saporta-report-migrate-galleries',
+			[ $this, 'cmd_migrate_galleries' ],
+			[
+				'shortdesc' => 'Migrate Photonic Galleries to Co-Authors Plus.',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'batch',
+						'description' => 'Batch to start from.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'posts-per-batch',
+						'description' => 'Posts to import per batch',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Callable for `newspack-content-migrator saporta-report-migrate-galleries`.
+	 *
+	 * @param array $args CLI args.
+	 * @param array $assoc_args CLI args.
+	 */
+	public function cmd_migrate_galleries( $args, $assoc_args ) {
+		$log_file        = 'saporta_report_migrate_galleries.log';
+		$posts_per_batch = isset( $assoc_args['posts-per-batch'] ) ? intval( $assoc_args['posts-per-batch'] ) : 10000;
+		$batch           = isset( $assoc_args['batch'] ) ? intval( $assoc_args['batch'] ) : 1;
+
+		$meta_query = [
+			[
+				'key'     => '_newspack_migration_gallery_migrated',
+				'compare' => 'NOT EXISTS',
+			],
+		];
+
+		$total_query = new \WP_Query(
+			[
+				'posts_per_page' => -1,
+				'post_type'      => 'post',
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'meta_query'     => $meta_query, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			]
+		);
+
+		WP_CLI::warning( sprintf( 'Total posts: %d', count( $total_query->posts ) ) );
+
+		$query = new \WP_Query(
+			[
+				'post_type'      => 'post',
+				'paged'          => $batch,
+				'posts_per_page' => $posts_per_batch,
+				'meta_query'     => $meta_query, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			]
+		);
+
+		$posts       = $query->get_posts();
+		$total_posts = count( $posts );
+
+		foreach ( $posts as $index => $post ) {
+			WP_CLI::line( sprintf( 'Post %d/%d', $index + 1, $total_posts ) );
+
+			$need_manual_fix = false;
+			$content_blocks  = array_map(
+                function( $block ) use ( &$need_manual_fix ) {
+					if ( 'core/shortcode' === $block['blockName'] && str_contains( $block['innerHTML'], '[photos ids' ) ) {
+						$shortcode      = str_replace( [ '’', '′' ], '"', mb_convert_encoding( $block['innerHTML'], 'UTF-8', 'HTML-ENTITIES' ) );
+						$raw_images_ids = $this->squarebracketselement_manipulator->get_attribute_value( 'ids', $shortcode );
+						$images_ids     = explode( ',', $raw_images_ids );
+						$style          = $this->squarebracketselement_manipulator->get_attribute_value( 'style', $shortcode );
+						if ( 'mosaic' === $style ) {
+							$need_manual_fix = true;
+							return $this->gutenberg_block_generator->get_jetpack_tiled_gallery( $images_ids );
+						} elseif ( 'thumbs' === $style ) {
+							return $this->gutenberg_block_generator->get_jetpack_slideshow( $images_ids );
+						}
+					}
+
+					return $block;
+				},
+                parse_blocks( $post->post_content )
+            );
+
+			$migrated_content = serialize_blocks( $content_blocks );
+			if ( $migrated_content !== $post->post_content ) {
+				wp_update_post(
+					array(
+						'ID'           => $post->ID,
+						'post_content' => $migrated_content,
+					)
+				);
+
+				$this->logger->log( $log_file, sprintf( 'Gallery migrated for the post %d', $post->ID ), Logger::SUCCESS );
+				if ( $need_manual_fix ) {
+					$this->logger->log( $log_file, sprintf( 'Please edit the post and fix manually the gallery block by clicking on `Attempt Block Recovery`: %spost.php?post=%d&action=edit"', get_admin_url(), $post->ID ), Logger::WARNING );
+				}
+			}
+
+			update_post_meta( $post->ID, '_newspack_migration_gallery_migrated', true );
+		}
+	}
+}

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -81,7 +81,7 @@ class GutenbergBlockGenerator {
 		return [
 			'blockName'    => 'jetpack/tiled-gallery',
 			'attrs'        => [
-				'columnWidths' => $tile_sizes,
+				'columnWidths' => [], // It will be filled after fixing the block manually from the backend.
 				'ids'          => $attachment_ids,
 			],
 			'innerBlocks'  => [],

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -2,11 +2,20 @@
 /**
  * Generator for Gutenberg Blocks content.
  *
+ * To add a new method to this class that generates a Gutenberg Block, please follow these instructions:
+ *     - Create a draft post in Gutenberg and add the desired block.
+ *     - Copy the source HTML of your block (from the code editor) and pass it to the `get_block_json_array_from_content` method.
+ *     - Transform the JSON result to a PHP array using a tool like https://wtools.io/convert-json-to-php-array
+ *     - The newly created method should return this PHP array.
+ *     - Add method parameters as necessary to customize the resulting array.
+ *     - The idea is to use the output of your method as an input to the serialize_block(s) to get the HTML content of the block.
+ *
  * @package GutenbergBlockGenerator
  */
 
 namespace NewspackCustomContentMigrator\Logic;
 
+use \NewspackCustomContentMigrator\Utils\Logger;
 use \WP_CLI;
 
 /**
@@ -15,6 +24,18 @@ use \WP_CLI;
  * @package NewspackCustomContentMigrator\Logic
  */
 class GutenbergBlockGenerator {
+    /**
+	 * @var Logger.
+	 */
+	private $logger;
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->logger = new Logger();
+	}
+
     /**
      * Generate a Jetpack Tiled Gallery Block.
      *
@@ -41,7 +62,7 @@ class GutenbergBlockGenerator {
 
                         if ( ! $attachment_url ) {
                             $non_existing_attachment_indexes[] = $index;
-                            WP_CLI::warning( sprintf( "Attachment %d doesn't exist!", $attachment_id ) );
+                            $this->logger->log( 'jetpack_tiled_gallery_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
                             return null;
                         }
 
@@ -107,7 +128,7 @@ class GutenbergBlockGenerator {
 		foreach ( $attachment_ids as $attachment_id ) {
             $attachment_post = get_post( $attachment_id );
             if ( ! $attachment_post ) {
-                WP_CLI::warning( sprintf( "Attachment %d doesn't exist!", $attachment_id ) );
+                $this->logger->log( 'jetpack_slideshow_migrator.log', sprintf( "Attachment %d doesn't exist!", $attachment_id ), Logger::WARNING );
                 continue;
             }
 

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Generator for Gutenberg Blocks content.
+ *
+ * @package GutenbergBlockGenerator
+ */
+
+namespace NewspackCustomContentMigrator\Logic;
+
+use \WP_CLI;
+
+/**
+ * Class ContentDiffMigrator and main logic.
+ *
+ * @package NewspackCustomContentMigrator\Logic
+ */
+class GutenbergBlockGenerator {
+    /**
+     * Generate a Jetpack Tiled Gallery Block.
+     *
+     * @param int[]    $attachment_ids Attachments IDs to be used in the tiled gallery.
+     * @param string[] $tile_sizes_list List of tiles sizes in percentages (e.g. ['50', '50']).
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_jetpack_tiled_gallery( $attachment_ids, $tile_sizes_list = [ '66.79014', '33.20986', '33.33333', '33.33333', '33.33333', '50.00000', '50.00000' ] ) {
+        $gallery_content = '
+        <div class="wp-block-jetpack-tiled-gallery aligncenter is-style-rectangular">
+            <div class="tiled-gallery__gallery">
+                <div class="tiled-gallery__row">
+        ';
+
+        $tile_sizes                      = [];
+        $non_existing_attachment_indexes = [];
+
+		$gallery_content .= join(
+            ' ',
+            array_filter(
+                array_map(
+                    function( $index, $attachment_id ) use ( &$tile_sizes, &$non_existing_attachment_indexes, $tile_sizes_list ) {
+                        $attachment_url = wp_get_attachment_url( $attachment_id );
+
+                        if ( ! $attachment_url ) {
+                            $non_existing_attachment_indexes[] = $index;
+                            WP_CLI::warning( sprintf( "Attachment %d doesn't exist!", $attachment_id ) );
+                            return null;
+                        }
+
+                        $tile_size    = $this->get_tile_image_size_by_index( $index, $tile_sizes_list );
+                        $tile_sizes[] = $tile_size;
+                        return '
+                            <div class="tiled-gallery__col" style="flex-basis: ' . $tile_size . '%">
+                            <figure class="tiled-gallery__item">
+                                <img
+                                        alt="' . get_the_title( $attachment_id ) . '"
+                                        data-id="' . $attachment_id . '"
+                                        data-link="' . $attachment_url . '"
+                                        data-url="' . $attachment_url . '"
+                                        src="' . $attachment_url . '"
+                                    data-amp-layout="responsive"
+                                />
+                            </figure>
+                            </div>';
+                    },
+                    array_keys( $attachment_ids ),
+                    $attachment_ids
+                )
+            )
+		);
+
+		$gallery_content .= '
+                </div>
+            </div>
+        </div>
+        ';
+
+        // delete unexisting attachments.
+        foreach ( $non_existing_attachment_indexes as $non_existing_attachment_index ) {
+            unset( $attachment_ids[ $non_existing_attachment_index ] );
+        }
+
+		return [
+			'blockName'    => 'jetpack/tiled-gallery',
+			'attrs'        => [
+				'columnWidths' => $tile_sizes,
+				'ids'          => $attachment_ids,
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => $gallery_content,
+			'innerContent' => [ $gallery_content ],
+        ];
+    }
+
+    /**
+     * Generate a Jetpack Slideshow Block.
+     *
+     * @param int[]     $attachment_ids Attachments IDs to be used in the tiled gallery.
+     * @param string    $transition Slideshow transition (slide or fade).
+     * @param int|false $autoplay False de disable, on the delay in seconds.
+     * @param string    $image_size Image size (thumbnail, medium, large, full).
+     * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
+     */
+    public function get_jetpack_slideshow( $attachment_ids, $transition = 'slide', $autoplay = false, $image_size = 'large' ) {
+        $data_autoplay = is_numeric( $autoplay ) ? 'data-autoplay="true" data-delay="' . $autoplay . '"' : '';
+        $data_effect   = 'data-effect="' . $transition . '"';
+
+        $attachment_posts = [];
+		foreach ( $attachment_ids as $attachment_id ) {
+            $attachment_post = get_post( $attachment_id );
+            if ( ! $attachment_post ) {
+                WP_CLI::warning( sprintf( "Attachment %d doesn't exist!", $attachment_id ) );
+                continue;
+            }
+
+			$attachment_posts[] = $attachment_post;
+		}
+
+        $slideshow_content = '
+            <div class="wp-block-jetpack-slideshow aligncenter" ' . $data_autoplay . ' ' . $data_effect . '>
+                <div class="wp-block-jetpack-slideshow_container swiper-container">
+                    <ul class="wp-block-jetpack-slideshow_swiper-wrapper swiper-wrapper">
+        ';
+
+        foreach ( $attachment_posts as $attachment_post ) {
+            $caption = ! empty( $attachment_post->post_excerpt ) ? $attachment_post->post_excerpt : $attachment_post->post_title;
+
+            $slideshow_content .= '<li class="wp-block-jetpack-slideshow_slide swiper-slide">
+            <figure>
+            <img alt="' . $attachment_post->post_title . '" class="wp-block-jetpack-slideshow_image wp-image-' . $attachment_post->ID . '" data-id="' . $attachment_post->ID . '" src="' . wp_get_attachment_url( $attachment_post->ID ) . '"/>
+            <figcaption class="wp-block-jetpack-slideshow_caption gallery-caption">' . $caption . '</figcaption>
+            </figure>
+            </li>';
+        }
+
+        $slideshow_content .= '</ul>
+                    <a class="wp-block-jetpack-slideshow_button-prev swiper-button-prev swiper-button-white" role="button"></a>
+                    <a class="wp-block-jetpack-slideshow_button-next swiper-button-next swiper-button-white" role="button"></a>
+                    <a aria-label="Pause Slideshow" class="wp-block-jetpack-slideshow_button-pause" role="button"></a>
+                    <div class="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-white"></div>
+                </div>
+            </div>';
+        return [
+            'blockName'    => 'jetpack/slideshow',
+            'attrs'        => [
+                'ids'      => $attachment_ids,
+                'sizeSlug' => $image_size,
+                'effect'   => $transition,
+                'autoplay' => $autoplay,
+            ],
+            'innerBlocks'  => [],
+            'innerHTML'    => $slideshow_content,
+            'innerContent' => [ $slideshow_content ],
+        ];
+    }
+
+    /**
+     * Generate tile size based on its index.
+     *
+     * @param int      $index Tile size.
+     * @param string[] $tile_sizes_list Tile sizes list in percentage (e.g. [ '66.79014', '33.20986', '33.33333', '33.33333', '33.33333', '50.00000', '50.00000' ]).
+     * @return string
+     */
+	private function get_tile_image_size_by_index( $index, $tile_sizes_list ) {
+		return $tile_sizes_list[ $index % count( $tile_sizes_list ) ];
+    }
+
+    /**
+     * Helper function used for getting the PHP array needed to generate a block.
+     * To be used the first time we're adding a new method to generate a block, to get the right array attributes.
+     *
+     * @param string $content content of one Gutenberg Block.
+     * @return string a JSON encoded array of the Gutenberg Block.
+     */
+    public function get_block_json_array_from_content( $content ) {
+        return json_encode( current( parse_blocks( $content ) ) ); // phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
+    }
+}

--- a/src/Utils/Logger.php
+++ b/src/Utils/Logger.php
@@ -7,12 +7,18 @@
 
 namespace NewspackCustomContentMigrator\Utils;
 
+use \WP_CLI;
+
 /**
  * Class for handling commands' logging
  */
 class Logger {
 
 	const LE_LOG_DIRECTORY = 'newspack_le_logs';
+
+	const WARNING = 'warning';
+	const LINE    = 'line';
+	const SUCCESS = 'success';
 
 	/**
 	 * Determine the writeable directory used for storing logs created by migration commands.
@@ -26,16 +32,28 @@ class Logger {
 	/**
 	 * Simple file logging.
 	 *
-	 * @param string  $file File name or path.
-	 * @param string  $message Log message.
-	 * @param boolean $to_cli Whether to output the message to the CLI. Default to false.
+	 * @param string         $file File name or path.
+	 * @param string         $message Log message.
+	 * @param string|boolean $level Whether to output the message to the CLI. Default to `line` CLI level.
 	 */
-	public function log( $file, $message, $to_cli = true ) {
+	public function log( $file, $message, $level = 'line' ) {
 		$message .= "\n";
-		if ( $to_cli ) {
-			WP_CLI::line( $message );
+		if ( $level ) {
+			switch ( $level ) {
+				case ( self::SUCCESS ):
+					WP_CLI::success( $message );
+				    break;
+				case ( self::WARNING ):
+					WP_CLI::warning( $message );
+		            break;
+				case ( self::LINE ):
+				default:
+					WP_CLI::line( $message );
+				    break;
+			}
 		}
-		file_put_contents( $file, $message, FILE_APPEND );
+
+		file_put_contents( $file, $message, FILE_APPEND ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 	}
 
 }

--- a/src/Utils/Logger.php
+++ b/src/Utils/Logger.php
@@ -38,7 +38,6 @@ class Logger {
 	 * @param string|boolean $level Whether to output the message to the CLI. Default to `line` CLI level.
 	 */
 	public function log( $file, $message, $level = 'line' ) {
-		$message .= "\n";
 		if ( $level ) {
 			switch ( $level ) {
 				case ( self::SUCCESS ):
@@ -57,7 +56,7 @@ class Logger {
 			}
 		}
 
-		file_put_contents( $file, $message, FILE_APPEND ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+		file_put_contents( $file, "\n" . $message, FILE_APPEND ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 	}
 
 }

--- a/src/Utils/Logger.php
+++ b/src/Utils/Logger.php
@@ -19,6 +19,7 @@ class Logger {
 	const WARNING = 'warning';
 	const LINE    = 'line';
 	const SUCCESS = 'success';
+	const ERROR   = 'error';
 
 	/**
 	 * Determine the writeable directory used for storing logs created by migration commands.
@@ -45,6 +46,9 @@ class Logger {
 				    break;
 				case ( self::WARNING ):
 					WP_CLI::warning( $message );
+		            break;
+				case ( self::ERROR ):
+					WP_CLI::error( $message );
 		            break;
 				case ( self::LINE ):
 				default:


### PR DESCRIPTION
This PR introduces the Saporta Report migrator and some internal tooling improvements. Some Commits that need some code review, please:

[101438b](https://github.com/Automattic/newspack-custom-content-migrator/pull/270/commits/101438bfc163100346d7f90ef6c97042add3c0d2) Adds logging levels when we log to CLI.

[c7b9cd6](https://github.com/Automattic/newspack-custom-content-migrator/pull/270/commits/c7b9cd6c509acad46ad760a902d867a70777719f) Introduce the Gutenberg Blocks Generator class, for now, it contains two functions to generate the `Jetpack Tiled Gallery` and the `Jetpack Slideshow` blocks, and a helper function to generate the blocks PHP array to be used for the upcoming methods.

The idea is that whenever we want to add a Gutenberg Block generator method, to create this block in a post, copy its code, below is an example of the Paragraph block, pass the code through the helper method `get_block_json_array_from_content` which will result in a JSON format array that we'll pass through a tool like [Convert JSON to PHP Array](https://wtools.io/convert-json-to-php-array) to get the PHP array code and use it in the Block generator method.