### PR TITLE
feat: exit with code 1 when exceeding Atomic memory limit

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -21,6 +21,7 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 
 require_once ABSPATH . 'wp-settings.php';
 
+PluginSetup::register_ticker();
 PluginSetup::setup_wordpress_importer();
 PluginSetup::register_migrators(
 	array(

--- a/src/PluginSetup.php
+++ b/src/PluginSetup.php
@@ -1,4 +1,5 @@
 <?php
+declare(ticks=1);
 
 namespace NewspackCustomContentMigrator;
 
@@ -9,9 +10,25 @@ use \WP_CLI;
  */
 class PluginSetup {
 	/**
+	 * Register a tick callback to check the if we exceed the memory limit.
+	 */
+	public static function register_ticker() {
+		register_tick_function(
+			function() {
+				$memory_usage = memory_get_usage( false );
+
+				if ( $memory_usage > 912680550 ) { // 0.85 GB in bytes, since the limit on Atomic is 1GB.
+					print_r( 'Exit due to memory usage: ' . $memory_usage );
+					exit( 1 );
+				}
+			}
+		);
+	}
+
+	/**
 	 * Registers migrators' commands.
 	 *
-	 * @param $migrator_classes Array of Command\InterfaceCommand classes.
+	 * @param array $migrator_classes Array of Command\InterfaceCommand classes.
 	 */
 	public static function register_migrators( $migrator_classes ) {
 		foreach ( $migrator_classes as $migrator_class ) {


### PR DESCRIPTION
This PR adds a ticker to exit script execution with an exit code equal to 1 when reaching 0.85GB of memory. The idea is not to reach the 1GB which will cause a hard stop from the atomic environment, by doing it this way we can catch the exit code and relaunch the script with a bash script like the one below. 

```bash
#!/bin/bash

till_done() {
    $@
    exitcode=$?

    if [ $exitcode -eq "1" ]
    then
        echo "Re-running ..."
        till_done "$@"
    fi
}

till_done "$@"
```

An example of executing a WP command this way would be:

```bash
./exec_till_done.sh wp newspack-content-migrator town-news-migrate-content --export-dir-path=/tmp/content_migration/export
```

The next step is to add this bash script to the knife tool so we don't have to upload it to each site where we want to execute heavy-lifting commands.