### PR TITLE
VT Digger, launch updates

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -58,7 +58,7 @@ PluginSetup::register_migrators(
 		Command\General\ContentFixerMigrator::class,
 		Command\General\XMLMigrator::class,
 		Command\General\PrelaunchSiteQAMigrator::class,
-		Command\General\MetroMirgator::class,
+		Command\General\MetroMigrator::class,
 		Command\General\ProfilePress::class,
 		Command\General\TownNewsMigrator::class,
 

--- a/src/Command/General/CoAuthorPlusMigrator.php
+++ b/src/Command/General/CoAuthorPlusMigrator.php
@@ -366,7 +366,7 @@ class CoAuthorPlusMigrator implements InterfaceCommand {
 		}
 
 		// Get all Post IDs in category and set GA.
-		$post_ids = $this->posts_logic->get_all_posts_ids_in_category( 'post', [ 'publish', 'future', 'draft', 'pending', 'private', 'inherit' ], $cat_id );
+		$post_ids = $this->posts_logic->get_all_posts_ids_in_category( $cat_id, 'post', [ 'publish', 'future', 'draft', 'pending', 'private', 'inherit' ] );
 		foreach ( $post_ids as $post_id ) {
 			$this->coauthorsplus_logic->assign_guest_authors_to_post( [ $ga_id ], $post_id, false );
 			WP_CLI::success( sprintf( 'Updated Post ID %d.', $post_id ) );

--- a/src/Command/General/InlineFeaturedImageMigrator.php
+++ b/src/Command/General/InlineFeaturedImageMigrator.php
@@ -89,8 +89,22 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 			'newspack-content-migrator hide-featured-image-if-used-in-post-content',
 			[ $this, 'cmd_hide_featured_image_if_used_in_post_content' ],
 			[
-				'shortdesc' => 'Hides featured image for post but only if that same image is used anywhere in post_content.',
+				'shortdesc' => 'Hides featured image for post if that same image is used in post_content. By default it hides the featured image only if that same image is used at the very beginning of post_content. Optionally, if --anywhere-in-post-content flag is used, it hides the featured image if that same image is used anywhere in post_content.',
 				'synopsis'  => [
+					[
+						'type'        => 'flag',
+						'name'        => 'dry-run',
+						'description' => 'Do a dry run.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'flag',
+						'name'        => 'anywhere-in-post-content',
+						'description' => 'If this flag is set, featured image will be hidden if that same image is used anywhere in post_content.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-ids-csv',
@@ -124,28 +138,26 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 	 * @param array $assoc_args Associative arguments.
 	 */
 	public function cmd_hide_featured_image_if_used_in_post_content( $pos_args, $assoc_args ) {
-		$post_ids     = isset( $assoc_args['post-ids-csv'] ) && ! empty( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
-		$post_id_from = isset( $assoc_args['post-id-from'] ) && ! empty( $assoc_args['post-id-from'] ) ? $assoc_args['post-id-from'] : null;
-		$post_id_to   = isset( $assoc_args['post-id-to'] ) && ! empty( $assoc_args['post-id-to'] ) ? $assoc_args['post-id-to'] : null;
+		global $wpdb;
+		$log = 'hide-featured-image-if-used-in-post-content.log';
 
+		$dry_run                  = isset( $assoc_args['dry-run'] ) ? true : false;
+		$anywhere_in_post_content = isset( $assoc_args['anywhere-in-post-content'] ) ? true : false;
+		$post_ids                 = isset( $assoc_args['post-ids-csv'] ) && ! empty( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
+		$post_id_from             = isset( $assoc_args['post-id-from'] ) && ! empty( $assoc_args['post-id-from'] ) ? $assoc_args['post-id-from'] : null;
+		$post_id_to               = isset( $assoc_args['post-id-to'] ) && ! empty( $assoc_args['post-id-to'] ) ? $assoc_args['post-id-to'] : null;
 		// If --post-ids-csv, can't use --post-id-from and --post-id-to.
 		if ( $post_ids && ( $post_id_from || $post_id_to ) ) {
 			WP_CLI::error( "Can't use both --post-ids-csv and --post-id-from/--post-id-to." );
 		}
-
 		// If --post-id-from used, must use --post-id-to too.
 		if ( ( $post_id_from && ! $post_id_to ) || ( ! $post_id_from && $post_id_to ) ) {
 			WP_CLI::error( 'Muse provide both --post-id-from and --post-id-to.' );
 		}
-
-		global $wpdb;
-		$log = 'hide-featured-image-if-used-in-post-content.log';
-
 		// Will first use --post-ids-csv if provided.
 		if ( $post_ids ) {
 			WP_CLI::line( 'Checking provided --post-ids-csv...' );
 		}
-
 		// Get post ID range if specified.
 		if ( ! $post_ids && ( $post_id_from && $post_id_to ) ) {
 			WP_CLI::line( sprintf( 'Fetching post IDs in range between %d and %d...', $post_id_from, $post_id_to ) );
@@ -165,17 +177,20 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 				WP_CLI::error( 'No post IDs found in range.' );
 			}
 		}
-
 		// Use all posts if no post IDs specified.
 		if ( ! $post_ids ) {
-			WP_CLI::line( 'Fetching all post IDs...' );
-			$post_ids = $this->post_logic->get_all_posts_ids();
+			WP_CLI::line( "Fetching all published post IDs..." );
+			$post_ids = $this->post_logic->get_all_posts_ids( 'post', [ 'publish' ] );
 		}
+
+		// Timestamp log.
+		$this->logger->log( $log, sprintf( 'Starting %s', date('Y-m-d H:I:s') ) );
 
 		// Go through IDs.
 		foreach ( $post_ids as $key_post_id => $post_id ) {
 			WP_CLI::line( sprintf( '(%d)/(%d) %d', $key_post_id + 1, count( $post_ids ), $post_id ) );
 
+			// Validate post ID.
 			$post_id_exists = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE ID = %d", $post_id ) );
 			if ( ! $post_id_exists ) {
 				$this->logger->log( $log, sprintf( 'Post ID does not exist %d', $post_id ), $this->logger::WARNING );
@@ -197,25 +212,130 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 			}
 
 			// Get featured image URL.
-			$featured_image_url                  = wp_get_attachment_url( $thumbnail_id );
-			$featured_image_url_no_host          = str_replace( home_url(), '', $featured_image_url );
-			$featured_image_used_in_post_content = false !== strpos( $post_content, $featured_image_url_no_host );
-			if ( ! $featured_image_used_in_post_content ) {
-				$this->logger->log( $log, sprintf( 'Featured image not found in post_content %d', $post_id ) );
-				continue;
-			}
+			$featured_image_url     = wp_get_attachment_url( $thumbnail_id );
+			$parsed_url             = parse_url( $featured_image_url );
+			$featured_image_no_host = $parsed_url['path'];
 
-			// Set featured image as hidden if it's used in post_content.
-			if ( $featured_image_used_in_post_content ) {
-				update_post_meta( $post_id, 'newspack_featured_image_position', 'hidden' );
-				$this->logger->log( $log, sprintf( 'Featured image hidden %d', $post_id ) );
-				continue;
+			/**
+			 * Images can contain size modifiers in URL path, e.g. "img-300x200.jpg", which could be the same image as "img.jpg", but not necessarily.
+			 * That's tricky -- e.g. even \attachment_url_to_postid( "img-300x200.jpg" ) does not match this to be the attachment "img.jpg", if it indeed is the same image that's being used.
+			 * Here doing a couple of search strategies, starting with the safest ones. Extend if needed.
+			 */
+
+			// Hide featured image if used anywhere in post_content.
+			if ( $anywhere_in_post_content ) {
+
+				// Check if image url is used anywhere in post_content.
+				$featured_image_used_in_post_content = false !== strpos( $post_content, $featured_image_no_host );
+				if ( ! $featured_image_used_in_post_content ) {
+					$this->logger->log( $log, sprintf( 'Featured image not found in post_content %d', $post_id ) );
+					continue;
+				}
+
+				// Hide featured image.
+				if ( $featured_image_used_in_post_content ) {
+					if ( ! $dry_run ) {
+						update_post_meta( $post_id, 'newspack_featured_image_position', 'hidden' );
+					}
+					$this->logger->log( $log, sprintf( 'Featured image hidden %d', $post_id ), $this->logger::SUCCESS );
+					continue;
+				}
+
+			} else {
+
+				// Hide featured image only if post_content starts with that same image.
+				$post_content_starts_with_featured_image = false;
+
+				$content    = trim( get_post_field( 'post_content', $post_id ) );
+				$image_src  = wp_get_attachment_image_src( $thumbnail_id, 'full' );
+				$image_path = wp_parse_url( $image_src[0] )['path'];
+
+				/**
+				 * Search 1: Search for image block with featured image at beginning of post_content by referencing attachment ID.
+				 */
+				$pattern_subject_begins_w_wpimage_w_attachment_id = '|
+					\A          # Beginning of subject string
+					\<\!--\swp:image    # image block opening
+					[^{]*       # anything but opening curly brace
+					{           # opening curly brace
+					[^}]*       # anything but closing curly brace
+					"id":' . absint( $thumbnail_id ) . '      # attachment id
+					.*?         # anything in the middle
+					--\>        # end of opening tag
+					.*?         # anything in the middle
+					\<\!--\s/wp:image\s--\>                   # block closing tag
+					|xims';
+				/**
+				 * Regex modifiers explained:
+				 *      x - ignore withespaces
+				 *      i - case insensitive
+				 *      U - ungreedy
+				 *      m - multiline:
+				 *          - wp:image block is a multiline string so multiline modifier is needed
+				 *          - when 'm' is used, '^' stops meaning beginning of subject
+				 *          - using '\A' instead of '^' to signify beginning of subject
+				 */
+				preg_match( $pattern_subject_begins_w_wpimage_w_attachment_id, $content, $matches );
+				$post_content_starts_with_featured_image = isset( $matches[0] ) ? true : false;
+
+				/**
+				 * If not found, do Search 2: Search for image block with image URL.
+				 */
+				if ( ! $post_content_starts_with_featured_image ) {
+					if ( $image_src ) {
+						$sprintf_regex_img_block_with_any_string_inside = '|
+							\A                     # Beginning of subject string
+							<!--\swp:image
+							.*?                    # Match any character zero or more times
+							%s                     # use sprintf() to insert string for this placeholder
+							.*?                    # Match any character zero or more times
+							\<\!--\s/wp:image\s--\>
+							|xims';
+						$regex_image_block_with_imagepath_inside = sprintf( $sprintf_regex_img_block_with_any_string_inside, addslashes( $image_path ) );
+						preg_match( $regex_image_block_with_imagepath_inside, $content, $matches );
+						$post_content_starts_with_featured_image = isset( $matches[0] ) ? true : false;
+					}
+				}
+
+				/**
+				 * If still not found do Search 3: HTML img element with relative source.
+				 */
+				if ( ! $post_content_starts_with_featured_image ) {
+					$img_element_regex = '|
+						\A          # Beginning of subject string
+						(?:<p>)?    # Optional <p> tag at the beginning -- Gutenberg inserts it sometimes.
+						<img
+						[^>]*       # anything but closing bracket
+						src="
+						[^"]*       # anything but double quote -- this allows for relative URLs
+						' . addslashes( $image_path ) . '
+						[^"]*       # anything but double quote -- this allows for GET params
+						"
+						[^>]*       # anything but closing bracket -- this allows for img element tags
+						>
+						|xims';
+					preg_match( $img_element_regex, $content, $matches );
+					$post_content_starts_with_featured_image = isset( $matches[0] ) ? true : false;
+				}
+
+				// Hide featured image if image found at beginning of post_content.
+				if ( $post_content_starts_with_featured_image ) {
+					if ( ! $dry_run ) {
+						update_post_meta( $post_id, 'newspack_featured_image_position', 'hidden' );
+					}
+					$this->logger->log( $log, sprintf( 'Featured image hidden %d', $post_id ), $this->logger::SUCCESS );
+					continue;
+				}
+
 			}
 
 			$this->logger->log( $log, sprintf( 'No changes to post %d', $post_id ) );
 		}
 
-		WP_CLI::line( sprintf( 'Done. See %s', $log ) );
+		WP_CLI::success( sprintf( 'Done. See %s', $log ) );
+		if ( $dry_run ) {
+			WP_CLI::warning( 'This was a dry run. No changes were made.' );
+		}
 	}
 
 	/**

--- a/src/Command/General/MetroMigrator.php
+++ b/src/Command/General/MetroMigrator.php
@@ -6,11 +6,11 @@ use NewspackCustomContentMigrator\Command\InterfaceCommand;
 use NewspackCustomContentMigrator\Logic\Attachments;
 use WP_CLI;
 
-class MetroMirgator implements InterfaceCommand {
+class MetroMigrator implements InterfaceCommand {
 
 	private $ids_mappings;
 	private $mappings_folder;
-	
+
 	/**
 	 * @var null|InterfaceCommand Instance.
 	 */
@@ -206,10 +206,10 @@ class MetroMirgator implements InterfaceCommand {
 
 		$uploads_path = wp_upload_dir()['basedir'];
 
-		foreach ( $attachments as $attachment ) {			
+		foreach ( $attachments as $attachment ) {
 			$filename = path_join( $uploads_path, $attachment->file );
 			$new_filename = path_join( $uploads_path, $filename . 'g' );
-			
+
 			WP_CLI::log( sprintf( 'Renaming attachement #%d filename from %s to %s', $attachment->ID , $filename, $filename . 'g' ) );
 
 			if ( ! file_exists( $filename ) ) {
@@ -264,7 +264,7 @@ class MetroMirgator implements InterfaceCommand {
 		$files_folder = $assoc_args['files-folder'];
 
 		$locations = $this->get_objects_from_folder( $files_folder );
-		
+
 		foreach ( $locations as $location ) {
 			if ( $this->location_exists( $location->uuid ) ) {
 				WP_CLI::log( sprintf( 'Location "%s" already exists. Skipping...', $location->title ) );
@@ -337,7 +337,7 @@ class MetroMirgator implements InterfaceCommand {
 			WP_CLI::log( sprintf( 'Importing attachment "%s"', $file_data->filename  ) );
 
 			$file_path = path_join( $files_folder, $file_data->uuid . '.data' );
-			
+
 			$result = $this->add_file( $file_data, $file_path );
 			if ( is_wp_error( $result ) ) {
 				WP_CLI::warning( sprintf( 'Could not add attachment "%s"', $file_data->filename ) );
@@ -381,7 +381,7 @@ class MetroMirgator implements InterfaceCommand {
 			if ( 'describes' != $this->get_object_id( $tag->uuid, 'tags_types') ) {
 				continue;
 			}
-			
+
 			if ( $this->tag_exists( $tag->uuid ) ) {
 				WP_CLI::log( sprintf( 'Tag "%s" already exists. Skipping...', $tag->title ) );
 				continue;
@@ -426,7 +426,7 @@ class MetroMirgator implements InterfaceCommand {
 
 	public function cmd_metro_import_sections( $args, $assoc_args ) {
 		$files_folder = $assoc_args['files-folder'];
-		
+
 		$sections = $this->get_objects_from_folder( $files_folder );
 
 		if ( $sections == false ) {
@@ -460,7 +460,7 @@ class MetroMirgator implements InterfaceCommand {
 
 			$this->add_category( $section, $parent_id );
 		}
-		
+
 		if ( count( $need_parents ) > 0 ) {
 			$this->add_categories( $need_parents );
 		}
@@ -511,7 +511,7 @@ class MetroMirgator implements InterfaceCommand {
 		}
 
 		$post->content = '';
-		
+
 		$post_meta = array(
 			'newspack_post_subtitle' => $post->sub_title,
 			'newspack_canonical_url' => $post->canonical_url,
@@ -545,7 +545,7 @@ class MetroMirgator implements InterfaceCommand {
 		}
 
 		$featured_image = $post->feature_image_url ? $post->feature_image_url : $post->teaser_image_url;
-		
+
 		if ( $featured_image ) {
 			$featured_image_uuid = end( explode( '/', $featured_image ) );
 			$featured_image_id = $this->get_attachment_id( $featured_image_uuid );
@@ -650,13 +650,13 @@ HTML;
 
 		$tmpfname = wp_tempnam( $file_path );
 		copy( $file_path, $tmpfname );
-		
+
 		$file_array = array(
 			'name'     => $data->filename,
 			'tmp_name' => $tmpfname,
 			'type' => $data->mimetype,
 		);
-		
+
 		$post_data = array(
 			'post_title' => $data->title ?? '',
 			'post_date' => $data->created,

--- a/src/Command/PublisherSpecific/VTDiggerMigrator.php
+++ b/src/Command/PublisherSpecific/VTDiggerMigrator.php
@@ -509,6 +509,9 @@ class VTDiggerMigrator implements InterfaceCommand {
 			//
 			$post_data = $old_post_ids_to_categories_data[ $old_post_id ];
 			if ( ! $post_data && $old_post_id ) {
+				if ( ! $live_row ) {
+					$live_row = $wpdb->get_row( $wpdb->prepare( "select * from live_posts where ID = %d", $old_post_id ), ARRAY_A );
+				}
 				if ( $live_row && ( 'business_briefs' == $live_row['post_type'] ) ) {
 					$post_data['post_type'] = self::BUSINESSBRIEFS_CPT;
 				} elseif ( $live_row && ( self::CARTOONS_CPT == $live_row['post_type'] ) ) {

--- a/src/Command/PublisherSpecific/VTDiggerMigrator.php
+++ b/src/Command/PublisherSpecific/VTDiggerMigrator.php
@@ -878,10 +878,6 @@ class VTDiggerMigrator implements InterfaceCommand {
 
 			// Get categories.
 			$categories = $this->get_categories_for_post( 'live_', $live_id );
-			// Live doesn't have children cats, debug-check anyways.
-			if ( 0 != $categories['parent'] ) {
-				$d = 1;
-			}
 			// Remove categories.
 			if ( 1 == count( $categories ) && ( 'Uncategorized' == $categories[0]['name'] ) ) {
 				$set = wp_set_post_categories( $staging_id, [], $append = false );

--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -1218,7 +1218,10 @@ class ContentDiffMigrator {
 			}
 
 			// Get attachment ID from block header.
-			$att_id = $block_updated['attrs']['id'];
+			$att_id = isset( $block_updated['attrs']['id'] ) ? $block_updated['attrs']['id'] : null;
+			if ( ! $att_id ) {
+				return $content_updated;
+			}
 
 			// Get the first <img> element from innerHTML -- there must be just one inside the image block.
 			$matches = $this->html_element_manipulator->match_elements_with_self_closing_tags( 'img', $block_innerhtml_updated );
@@ -1307,7 +1310,10 @@ class ContentDiffMigrator {
 			$block_innercontent_updated = $block['innerContent'][0];
 
 			// Get attachment ID from block header.
-			$att_id = $block_updated['attrs']['id'];
+			$att_id = isset( $block_updated['attrs']['id'] ) ? $block_updated['attrs']['id'] : null;
+			if ( ! $att_id ) {
+				return $content_updated;
+			}
 
 			// Get the first <audio> element from innerHTML.
 			$matches = $this->html_element_manipulator->match_elements_with_self_closing_tags( 'audio', $block_innerhtml_updated );
@@ -1393,7 +1399,10 @@ class ContentDiffMigrator {
 			$block_innercontent_updated = $block['innerContent'][0];
 
 			// Get attachment ID from block header.
-			$att_id = $block_updated['attrs']['id'];
+			$att_id = isset( $block_updated['attrs']['id'] ) ? $block_updated['attrs']['id'] : null;
+			if ( ! $att_id ) {
+				return $content_updated;
+			}
 
 			// Get the first <video> element from innerHTML.
 			$matches = $this->html_element_manipulator->match_elements_with_self_closing_tags( 'video', $block_innerhtml_updated );
@@ -1479,7 +1488,10 @@ class ContentDiffMigrator {
 			$block_innercontent_updated = $block['innerContent'][0];
 
 			// Get attachment ID from block header.
-			$att_id = $block_updated['attrs']['id'];
+			$att_id = isset( $block_updated['attrs']['id'] ) ? $block_updated['attrs']['id'] : null;
+			if ( ! $att_id ) {
+				return $content_updated;
+			}
 
 			// Get the first <a> elementa from innerHTML.
 			$matches = $this->html_element_manipulator->match_elements_with_self_closing_tags( 'a', $block_innerhtml_updated );
@@ -1565,7 +1577,10 @@ class ContentDiffMigrator {
 			$block_innercontent_updated = $block['innerContent'][0];
 
 			// Get attachment ID from block header.
-			$att_id = $block_updated['attrs']['id'];
+			$att_id = isset( $block_updated['attrs']['id'] ) ? $block_updated['attrs']['id'] : null;
+			if ( ! $att_id ) {
+				return $content_updated;
+			}
 
 			// Get the first <img> element from innerHTML.
 			$matches = $this->html_element_manipulator->match_elements_with_self_closing_tags( 'img', $block_innerhtml_updated );
@@ -1654,7 +1669,10 @@ class ContentDiffMigrator {
 			$block_innercontent_updated = $block['innerContent'][0];
 
 			// Get mediaID (attachment ID) from block header.
-			$att_id = $block_updated['attrs']['mediaId'];
+			$att_id = isset( $block_updated['attrs']['mediaId'] ) ? $block_updated['attrs']['mediaId'] : null;
+			if ( ! $att_id ) {
+				return $content_updated;
+			}
 
 			// Get the first <img> element from innerHTML.
 			$matches = $this->html_element_manipulator->match_elements_with_self_closing_tags( 'img', $block_innerhtml_updated );

--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -1318,9 +1318,6 @@ class ContentDiffMigrator {
 				return $content_updated;
 			}
 
-			// Cast to integer type for proper JSON encoding.
-			$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
-
 			// Get the first <audio> element from innerHTML.
 			$matches = $this->html_element_manipulator->match_elements_with_self_closing_tags( 'audio', $block_innerhtml_updated );
 			if ( is_null( $matches ) || ! isset( $matches[0][0][0] ) || empty( $matches[0][0][0] ) ) {
@@ -1357,6 +1354,9 @@ class ContentDiffMigrator {
 			if ( $att_id === $new_att_id ) {
 				continue;
 			}
+
+			// Cast to integer type for proper JSON encoding.
+			$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
 
 			// Update the whole audio HTML element in Block HTML.
 			$block_innerhtml_updated    = str_replace( $audio_html, $audio_html_updated, $block_innerhtml_updated );

--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -1260,6 +1260,9 @@ class ContentDiffMigrator {
 				continue;
 			}
 
+			// Cast to integer type for proper JSON encoding.
+			$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
+
 			// Update ID in image element `class` attribute.
 			$img_html_updated = $this->update_image_element_class_attribute( [ $att_id => $new_att_id ], $img_html_updated );
 
@@ -1314,6 +1317,9 @@ class ContentDiffMigrator {
 			if ( ! $att_id ) {
 				return $content_updated;
 			}
+
+			// Cast to integer type for proper JSON encoding.
+			$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
 
 			// Get the first <audio> element from innerHTML.
 			$matches = $this->html_element_manipulator->match_elements_with_self_closing_tags( 'audio', $block_innerhtml_updated );
@@ -1441,6 +1447,9 @@ class ContentDiffMigrator {
 				continue;
 			}
 
+			// Cast to integer type for proper JSON encoding.
+			$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
+
 			// Update the whole video HTML element in Block HTML.
 			$block_innerhtml_updated    = str_replace( $video_html, $video_html_updated, $block_innerhtml_updated );
 			$block_innercontent_updated = str_replace( $video_html, $video_html_updated, $block_innercontent_updated );
@@ -1530,6 +1539,9 @@ class ContentDiffMigrator {
 				continue;
 			}
 
+			// Cast to integer type for proper JSON encoding.
+			$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
+
 			// Update the whole a HTML element in Block HTML.
 			$block_innerhtml_updated    = str_replace( $a_html, $a_html_updated, $block_innerhtml_updated );
 			$block_innercontent_updated = str_replace( $a_html, $a_html_updated, $block_innercontent_updated );
@@ -1618,6 +1630,9 @@ class ContentDiffMigrator {
 			if ( $att_id === $new_att_id ) {
 				continue;
 			}
+
+			// Cast to integer type for proper JSON encoding.
+			$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
 
 			// Update ID in image element `class` attribute.
 			$img_html_updated = $this->update_image_element_class_attribute( [ $att_id => $new_att_id ], $img_html_updated );
@@ -1711,10 +1726,8 @@ class ContentDiffMigrator {
 				continue;
 			}
 
-			// If it's the same ID, don't update anything.
-			if ( $att_id === $new_att_id ) {
-				continue;
-			}
+			// Cast to integer type for proper JSON encoding.
+			$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
 
 			// Update ID in image element `class` attribute.
 			$img_html_updated = $this->update_image_element_class_attribute( [ $att_id => $new_att_id ], $img_html_updated );
@@ -1807,6 +1820,9 @@ class ContentDiffMigrator {
 				if ( $att_id === $new_att_id ) {
 					continue;
 				}
+
+				// Cast to integer type for proper JSON encoding.
+				$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
 
 				// Update `data-id` attribute.
 				$img_html_updated = $this->update_image_element_attribute( 'data-id', [ $att_id => $new_att_id ], $img_html_updated );
@@ -1906,6 +1922,9 @@ class ContentDiffMigrator {
 				if ( $att_id === $new_att_id ) {
 					continue;
 				}
+
+				// Cast to integer type for proper JSON encoding.
+				$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
 
 				// Update `data-id` attribute.
 				$img_html_updated = $this->update_image_element_attribute( 'data-id', [ $att_id => $new_att_id ], $img_html_updated );
@@ -2007,6 +2026,9 @@ class ContentDiffMigrator {
 				if ( $att_id === $new_att_id ) {
 					continue;
 				}
+
+				// Cast to integer type for proper JSON encoding.
+				$new_att_id = ( is_numeric( $new_att_id ) && (int) $new_att_id == $new_att_id ) ? (int) $new_att_id : $new_att_id;
 
 				// Update `id` attribute.
 				$img_html_updated = $this->update_image_element_attribute( 'id', [ $att_id => $new_att_id ], $img_html_updated );

--- a/src/Logic/Posts.php
+++ b/src/Logic/Posts.php
@@ -46,13 +46,13 @@ class Posts {
 	/**
 	 * Returns all Post IDs in a given category.
 	 *
+	 * @param int          $category_term_id Category ID.
 	 * @param string|array $post_type        Post type(s).
 	 * @param array        $post_status      Post statuses.
-	 * @param int          $category_term_id Category ID.
 	 *
 	 * @return array
 	 */
-	public function get_all_posts_ids_in_category( $post_type = 'post', $post_status = [ 'publish', 'future', 'draft', 'pending', 'private', 'inherit' ], $category_term_id ) {
+	public function get_all_posts_ids_in_category( $category_term_id, $post_type = 'post', $post_status = [ 'publish', 'future', 'draft', 'pending', 'private', 'inherit' ] ) {
 		global $wpdb;
 
 		// Create $post_type statement placeholders.
@@ -69,7 +69,7 @@ class Posts {
 			$wpdb->prepare(
 				"select term_taxonomy_id from {$wpdb->term_taxonomy} where term_id = %d;",
 				$category_term_id
-			) 
+			)
 		);
 		if ( ! $term_taxonomy_id ) {
 			throw new \UnexpectedValueException( sprintf( 'Term taxonomy ID not found for term_id %s.', $category_term_id ) );

--- a/src/Logic/Taxonomy.php
+++ b/src/Logic/Taxonomy.php
@@ -100,7 +100,7 @@ class Taxonomy {
 					join {$wpdb->term_taxonomy} tt on tt.term_id = t.term_id 
 					where tt.taxonomy = %s and t.name = %s and tt.parent = %d;",
 				$taxonomy,
-				$name,
+				htmlentities( $name ),
 				$parent_term_id
 			)
 		);


### PR DESCRIPTION
Besides publisher-specific code, here merging a couple of general type contributions:
- src/Command/General/InlineFeaturedImageMigrator.php, `newspack-content-migrator hide-featured-image-if-used-in-post-content` command
  - updated this command so that **by default it hides the featured image only if post_content starts with that image**
  - added optional flag `--anywhere-in-post-content`, which will not hide featured image just if post_content **begins** with that image, but also if that image is used **anywhere** in post_content
  - added `dry-run` flag
- ContentDiff logic class -- fixed some warnings (they were caused because some Gutenberg blocks (for example wp:image) have the `id` attribute, but some don't -- if image is inserted from remote URL, not from Media Library)
- Taxonomy logic class -- tiny update to already existing custom method, added character encoding to match WP internal logic
- Posts logic class, get_all_posts_ids_in_category() -- just updated order of arguments so that mandatory argument is first, and optional arguments are last (also updated all usage across plugin files)