### PR TITLE
More verbose import warnings on CLI output

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://newspack.blog/
  * Author:      Automattic
  * Author URI:  https://newspack.blog/
- * Version:     1.3.3
+ * Version:     1.3.4
  *
  * @package  Newspack_Custom_Content_Migrator
  */


### PR DESCRIPTION
Not waiting for a full PR review for this one because it only improves message outputs.

Sometimes live DBs are faulty -- for example, there could be invalid term_relationships, or completely missing terms. Nothing we can do in that case, and warnings must happen.

Previous warnings were very general. This now outputs more verbose warnings on screen, but at least it's clearer that it's an error in Live DB, not in Content Diff code.

Example before:
![image](https://github.com/Automattic/newspack-custom-content-migrator/assets/29167323/fe53bcec-80ad-497c-a4ff-699bf2055eeb)

Example after:
![image](https://github.com/Automattic/newspack-custom-content-migrator/assets/29167323/64a1574a-99bb-47a5-9f71-305520a2efaf)

Though more verbose, we can immediately see that it's a "faulty term_relationship record in live DB".

Perhaps we could even skip outputting warnings completely for these? If you think so, please share and we can hide them in the future.