### PR TITLE
Config plugin to dev debugging and error display level

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -21,6 +21,7 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 
 require_once ABSPATH . 'wp-settings.php';
 
+PluginSetup::configure_error_reporting( 'dev' );
 PluginSetup::register_ticker();
 PluginSetup::setup_wordpress_importer();
 PluginSetup::register_migrators(

--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -21,7 +21,7 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 
 require_once ABSPATH . 'wp-settings.php';
 
-PluginSetup::configure_error_reporting( 'dev' );
+PluginSetup::configure_error_reporting();
 PluginSetup::register_ticker();
 PluginSetup::setup_wordpress_importer();
 PluginSetup::register_migrators(

--- a/src/PluginSetup.php
+++ b/src/PluginSetup.php
@@ -26,6 +26,34 @@ class PluginSetup {
 	}
 
 	/**
+	 * Configures all errors and warnings will be output to CLI.
+	 * 
+	 * @param string $level Error reporting level. Presently defaults to 'dev' but can be extended.
+	 */
+	public static function configure_error_reporting( $level = 'dev' ) {
+		if ( 'dev' === $level ) {
+			// phpcs:disable -- Adds extra debugging config options for dev purposes.
+			@ini_set( 'display_errors', 1 );
+			@ini_set( 'display_startup_errors', 1 );
+			error_reporting( E_ALL );
+			// phpcs:enable
+
+			// Enable WP_DEBUG mode.
+			if ( ! defined( 'WP_DEBUG' ) ) {
+				define( 'WP_DEBUG', true );
+			}
+			// Enable Debug logging to the /wp-content/debug.log file.
+			if ( ! defined( 'WP_DEBUG_LOG' ) ) {
+				define( 'WP_DEBUG_LOG', true );
+			}
+			// Enable display of errors and warnings.
+			if ( ! defined( 'WP_DEBUG_DISPLAY' ) ) {
+				define( 'WP_DEBUG_DISPLAY', true );
+			}
+		}
+	}
+
+	/**
 	 * Registers migrators' commands.
 	 *
 	 * @param array $migrator_classes Array of Command\InterfaceCommand classes.


### PR DESCRIPTION
This is a purely dev plugin and we want to see all warnings on screen.

Sometimes when running my own or others' code, I find missed warnings that end up only in debug.log, and author (me or someone else) hasn't noticed them.

This ensures all warnings and errors get output to screen and logged to debug.log on plugin-run-level.