### PR TITLE
feat: logic func which will throw exception if core WP tables are empty.

### DIFF
--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -1292,15 +1292,18 @@ class ContentDiffMigrator implements InterfaceCommand {
 	 * @param string $live_table_prefix Live table prefix.
 	 * @param array  $skip_tables       Core WP DB tables to skip (without prefix).
 	 *
-	 * @throws \RuntimeException In case that table collations do not match.
+	 * @throws \RuntimeException In case that table collations do not match, or any core WP tables are empty.
 	 *
 	 * @return void
 	 */
 	public function validate_db_tables( string $live_table_prefix, array $skip_tables ): void {
 		self::$logic->validate_core_wp_db_tables_exist_in_db( $live_table_prefix, $skip_tables );
+
 		if ( ! self::$logic->are_table_collations_matching( $live_table_prefix, $skip_tables ) ) {
 			throw new \RuntimeException( 'Table collations do not match for some (or all) WP tables.' );
 		}
+
+        self::$logic->validate_core_wp_db_tables_are_not_empty( $live_table_prefix, $skip_tables );
 	}
 
 	/**

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -1331,8 +1331,8 @@ class ContentDiffMigrator implements InterfaceCommand {
 	 * @param array  $skip_tables       Core WP DB tables to skip (without prefix).
 	 *
 	 * @return void
-	 * @throws \RuntimeException In case that table collations do not match
-	 * @throws CoreWPTableEmptyException In case that some of the core WP tables are empty
+	 * @throws \RuntimeException In case that table collations do not match.
+	 * @throws CoreWPTableEmptyException In case that some of the core WP tables are empty.
 	 */
 	public function validate_db_tables( string $live_table_prefix, array $skip_tables ): void {
 		self::$logic->validate_core_wp_db_tables_exist_in_db( $live_table_prefix, $skip_tables );

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -401,6 +401,9 @@ class ContentDiffMigrator implements InterfaceCommand {
 			// If one of the empty tables is wp_links, we can ignore it. Add any other tables we can ignore to the array below.
 			$ignore_empty_tables = [
 				$live_table_prefix . 'links',
+				$live_table_prefix . 'termmeta',
+				$live_table_prefix . 'comments',
+				$live_table_prefix . 'commentmeta',
 			];
 
 			$this->handle_core_wp_table_empty_exception( $e, $ignore_empty_tables );
@@ -523,6 +526,9 @@ class ContentDiffMigrator implements InterfaceCommand {
 			// If one of the empty tables is wp_links, we can ignore it. Add any other tables we can ignore to the array below.
 			$ignore_empty_tables = [
 				$live_table_prefix . 'links',
+				$live_table_prefix . 'termmeta',
+				$live_table_prefix . 'comments',
+				$live_table_prefix . 'commentmeta',
 			];
 
 			$this->handle_core_wp_table_empty_exception( $e, $ignore_empty_tables );

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -11,6 +11,7 @@ use NewspackCustomContentMigrator\Command\InterfaceCommand;
 use NewspackCustomContentMigrator\Exceptions\CoreWPTableEmptyException;
 use NewspackCustomContentMigrator\Logic\ContentDiffMigrator as ContentDiffMigratorLogic;
 use NewspackCustomContentMigrator\Utils\PHP as PHPUtil;
+use RuntimeException;
 use WP_CLI;
 
 /**
@@ -386,7 +387,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 		global $wpdb;
 		try {
 			$this->validate_db_tables( $live_table_prefix, [ 'options' ] );
-		} catch ( \RuntimeException $e ) {
+		} catch ( RuntimeException $e ) {
 			WP_CLI::warning( $e->getMessage() );
 			WP_CLI::line( "Now running command `newspack-content-migrator correct-collations-for-live-wp-tables --live-table-prefix={$live_table_prefix} --mode=generous --skip-tables=options` ..." );
 			$this->cmd_correct_collations_for_live_wp_tables(
@@ -511,7 +512,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 		// Validate DBs.
 		try {
 			$this->validate_db_tables( $live_table_prefix, [ 'options' ] );
-		} catch ( \RuntimeException $e ) {
+		} catch ( RuntimeException $e ) {
 			WP_CLI::warning( $e->getMessage() );
 			WP_CLI::line( "Now running command `newspack-content-migrator correct-collations-for-live-wp-tables --live-table-prefix={$live_table_prefix} --mode=generous --skip-tables=options` ..." );
 			$this->cmd_correct_collations_for_live_wp_tables(
@@ -1178,7 +1179,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 	 * @param string $where_operand           Search operand, can be '==' or '!='.
 	 * @param bool   $return_first            If true, return just the first matched entry, otherwise returns all matched entries.
 	 *
-	 * @throws \RuntimeException In case an unsupported $where_operand was given.
+	 * @throws RuntimeException In case an unsupported $where_operand was given.
 	 *
 	 * @return array Found results. Mind that if $return_first is true, it will return a one-dimensional array,
 	 *               and if $return_first is false, it will return two-dimensional array with all matched elements as subarrays.
@@ -1189,7 +1190,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 
 		// Validate $where_operand.
 		if ( ! in_array( $where_operand, $supported_where_operands ) ) {
-			throw new \RuntimeException( sprintf( 'Where operand %s is not supported.', $where_operand ) );
+			throw new RuntimeException( sprintf( 'Where operand %s is not supported.', $where_operand ) );
 		}
 
 		foreach ( $imported_posts_log_data as $entry ) {
@@ -1331,14 +1332,14 @@ class ContentDiffMigrator implements InterfaceCommand {
 	 * @param array  $skip_tables       Core WP DB tables to skip (without prefix).
 	 *
 	 * @return void
-	 * @throws \RuntimeException In case that table collations do not match.
+	 * @throws RuntimeException In case that table collations do not match.
 	 * @throws CoreWPTableEmptyException In case that some of the core WP tables are empty.
 	 */
 	public function validate_db_tables( string $live_table_prefix, array $skip_tables ): void {
 		self::$logic->validate_core_wp_db_tables_exist_in_db( $live_table_prefix, $skip_tables );
 
 		if ( ! self::$logic->are_table_collations_matching( $live_table_prefix, $skip_tables ) ) {
-			throw new \RuntimeException( 'Table collations do not match for some (or all) WP tables.' );
+			throw new RuntimeException( 'Table collations do not match for some (or all) WP tables.' );
 		}
 
 		self::$logic->validate_core_wp_db_tables_are_not_empty( $live_table_prefix, $skip_tables );

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -1310,8 +1310,8 @@ class ContentDiffMigrator implements InterfaceCommand {
 	/**
 	 * Handles CoreWPTableEmptyException.
 	 *
-	 * @param CoreWPTableEmptyException $e
-	 * @param array                     $ignore_empty_tables
+	 * @param CoreWPTableEmptyException $e Exception object which specifies which tables are empty.
+	 * @param array                     $ignore_empty_tables Array of tables to ignore if empty.
 	 *
 	 * @return void
 	 */

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -1311,7 +1311,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 	 * Handles CoreWPTableEmptyException.
 	 *
 	 * @param CoreWPTableEmptyException $e
-	 * @param array $ignore_empty_tables
+	 * @param array                     $ignore_empty_tables
 	 *
 	 * @return void
 	 */
@@ -1333,7 +1333,6 @@ class ContentDiffMigrator implements InterfaceCommand {
 	 * @return void
 	 * @throws \RuntimeException In case that table collations do not match
 	 * @throws CoreWPTableEmptyException In case that some of the core WP tables are empty
-	 *
 	 */
 	public function validate_db_tables( string $live_table_prefix, array $skip_tables ): void {
 		self::$logic->validate_core_wp_db_tables_exist_in_db( $live_table_prefix, $skip_tables );
@@ -1342,7 +1341,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 			throw new \RuntimeException( 'Table collations do not match for some (or all) WP tables.' );
 		}
 
-        self::$logic->validate_core_wp_db_tables_are_not_empty( $live_table_prefix, $skip_tables );
+		self::$logic->validate_core_wp_db_tables_are_not_empty( $live_table_prefix, $skip_tables );
 	}
 
 	/**

--- a/src/Exceptions/CoreWPTableEmptyException.php
+++ b/src/Exceptions/CoreWPTableEmptyException.php
@@ -16,7 +16,7 @@ class CoreWPTableEmptyException extends \Exception {
 	 */
 	public function __construct( array $tables ) {
 		$this->tables = $tables;
-		parent::__construct( sprintf( 'The following core WP Tables are empty: %s' , implode( $this->tables ) ) );
+		parent::__construct( sprintf( 'The following core WP Tables are empty: %s', implode( $this->tables ) ) );
 	}
 
 	/**
@@ -24,8 +24,7 @@ class CoreWPTableEmptyException extends \Exception {
 	 *
 	 * @return string[]
 	 */
-	public function get_tables(): array
-	{
+	public function get_tables(): array {
 		return $this->tables;
 	}
 }

--- a/src/Exceptions/CoreWPTableEmptyException.php
+++ b/src/Exceptions/CoreWPTableEmptyException.php
@@ -1,10 +1,24 @@
 <?php
+/**
+ * CoreWPTableEmptyException class.
+ *
+ * @package NewspackCustomContentMigrator\Exceptions
+ */
 
 namespace NewspackCustomContentMigrator\Exceptions;
 
+/**
+ * Class CoreWPTableEmptyException.
+ *
+ * This class facilitates the handling of instances where core WP tables are empty. It might be necessary
+ * to ignore certain tables even if they are empty. This class will allow us to obtain that list of
+ * empty core tables and allow us to make a decision on a case-by-case basis how to proceed.
+ */
 class CoreWPTableEmptyException extends \Exception {
 
 	/**
+	 * Array of table names that are empty.
+	 *
 	 * @var string[] $tables Names of empty tables.
 	 */
 	protected array $tables = [];

--- a/src/Exceptions/CoreWPTableEmptyException.php
+++ b/src/Exceptions/CoreWPTableEmptyException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Exceptions;
+
+class CoreWPTableEmptyException extends \Exception {
+
+	/**
+	 * @var string[] $tables Names of empty tables.
+	 */
+	protected array $tables = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string[] $tables Table names.
+	 */
+	public function __construct( array $tables ) {
+		$this->tables = $tables;
+		parent::__construct( sprintf( 'The following core WP Tables are empty: %s' , implode( $this->tables ) ) );
+	}
+
+	/**
+	 * Returns the names of the empty tables.
+	 *
+	 * @return string[]
+	 */
+	public function get_tables(): array
+	{
+		return $this->tables;
+	}
+}

--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -7,6 +7,7 @@
 
 namespace NewspackCustomContentMigrator\Logic;
 
+use NewspackCustomContentMigrator\Exceptions\CoreWPTableEmptyException;
 use \WP_CLI;
 use \WP_User;
 use NewspackContentConverter\ContentPatcher\ElementManipulators\WpBlockManipulator;
@@ -3166,15 +3167,17 @@ class ContentDiffMigrator {
 		}
 	}
 
-    /**
-     * This function will ensure that the core WP DB tables are not empty. This is especially important
-     * for tables like wp_terms, wp_term_taxonomy, and wp_term_relationships. If these tables are empty,
-     * the site's taxonomies will not be recreated, and no terms will be associated with posts.
-     *
-     * @param string $table_prefix Table prefix.
-     * @param string[] $skip_tables Core WP DB tables to skip (without prefix).
-     * @return void
-     */
+	/**
+	 * This function will ensure that the core WP DB tables are not empty. This is especially important
+	 * for tables like wp_terms, wp_term_taxonomy, and wp_term_relationships. If these tables are empty,
+	 * the site's taxonomies will not be recreated, and no terms will be associated with posts.
+	 *
+	 * @param string $table_prefix Table prefix.
+	 * @param string[] $skip_tables Core WP DB tables to skip (without prefix).
+	 *
+	 * @return void
+	 * @throws CoreWPTableEmptyException
+	 */
     public function validate_core_wp_db_tables_are_not_empty( string $table_prefix, array $skip_tables = [] )
     {
         $empty_tables = [];
@@ -3193,7 +3196,7 @@ class ContentDiffMigrator {
         }
 
         if ( ! empty( $empty_tables ) ) {
-            throw new \RuntimeException( sprintf( 'Core WP DB tables %s are empty.', implode( ', ', $empty_tables ) ) );
+            throw new CoreWPTableEmptyException( $empty_tables );
         }
     }
 


### PR DESCRIPTION
During a recent content diff, somehow the live wp_terms table (the table with new content that we're trying to merge into the current database) was empty. This caused the function recreate_categories to not function as expected. This is because when it tries to gather all the categories which must be brought over, it does a JOIN with this wp_terms table. But if that table is empty, the query will return no results, even though the wp_terms_taxonomy table has valid categories to be imported.

This function attempts to prevent that from happening in the first place, by checking if any core WP tables are empty before proceeding in earnest with the content diff.