### PR TITLE
LSV: Fix user slugs

### DIFF
--- a/src/Command/PublisherSpecific/LaSillaVaciaMigrator.php
+++ b/src/Command/PublisherSpecific/LaSillaVaciaMigrator.php
@@ -2546,16 +2546,17 @@ BLOCK;
 				update_post_meta( $post_id, 'cap-user_login', $slug );
 
 				$sql    = $wpdb->prepare(
-					"UPDATE {$wpdb->terms} SET slug = '%s' WHERE slug = '%s'",
-					$slug,
-					'cap-' . ( $data['old_nicename'] ?? $old_post_name )
+					"UPDATE {$wpdb->terms} SET slug = '%s', name = '%s' WHERE slug = '%s'",
+					$post->post_name,
+					$post->post_title,
+					empty( $data['old_nicename'] ) ? $old_post_name : 'cap-' . $data['old_nicename']
 				);
 				$wpdb->query( $sql );
 
 				MigrationMeta::update( $post_id, $command_meta_key, 'term', $command_meta_version );
 			}
 
-			WP_CLI::success( sprintf( "Updated post_name on guest user with ID %d", $post_id ) );
+			WP_CLI::success( sprintf( "Updated slug for %s: %s", $post->post_title, get_author_posts_url( $post->ID ) . $slug ) );
 		}
 
 	}


### PR DESCRIPTION
I'm not confident this will not cause other problems, but this fixes the slugs for authors.

It's pretty heavy handed, but seems to get the job done. There are two commands - one for users and one for guest authors. Run the user one first.

```shell
wp newspack-content-migrator la-silla-vacia-update-user-slugs
wp newspack-content-migrator la-silla-vacia-update-guest-author-slugs
```

There are a lot of users to fix now. On my local machine the user slug update takes ~15 minutes to run. 

Some users have no first name, last name, or anything at all to make a slug from. I skip them because I don't know what to make a slug from. 