### PR TITLE
Try to guess the file extension for external file downloads without one

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -58,6 +58,16 @@ class Attachments {
 			'tmp_name' => $tmpfname,
 		];
 
+		// If the path does not have a file extension, let's try to find one for it.
+		// Without the extension, the upload will fail because WP will not allow that "file type".
+		if ( ! pathinfo( $path, PATHINFO_EXTENSION ) ) {
+			$mimetype           = mime_content_type( $tmpfname );
+			$probably_extension = array_search( $mimetype, wp_get_mime_types() );
+			if ( ! empty ( $probably_extension ) ) {
+				$file_array['name'] .= '.' . $probably_extension;
+			}
+		}
+
 		if ( $title ) {
 			$args['post_title'] = $title;
 		}


### PR DESCRIPTION
This fixes an edge case in `import_external_file()` where files would not get imported if the url (or file path) they are on does not have a file extension. It uses the mime type to try to sniff out what kind of file it could be. Not 100% good but a lot better than importing 0%