### PR TITLE
Try to find an existing file in the ML when adding external files

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -106,12 +106,14 @@ class Attachments {
 	}
 
 	/**
-	 * @param string $filepath
-	 * @param string $filename
+	 * Try to get the attachment ID for a file if one just like it has already been uploaded.
+	 *
+	 * @param string $filepath The path on the file system of the file to check if we have already uploaded.
+	 * @param string $filename (Optional) The file name including file extension – exclude if it is on the file path.
 	 *
 	 * @return int|null Attachment ID if found, null otherwise.
 	 */
-	public function maybe_get_exisiting_attachment_id( $filepath, $filename = '' ): int|null {
+	public function maybe_get_exisiting_attachment_id( string $filepath, string $filename = '' ): int|null {
 		if ( ! file_exists( $filepath ) ) {
 			return null;
 		}
@@ -119,6 +121,7 @@ class Attachments {
 		if ( empty( $filename ) ) {
 			$filename = basename( $filepath );
 		}
+
 		global $wpdb;
 		$like = '%' . $wpdb->esc_like( $filename );
 		$sql  = $wpdb->prepare(

--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -3,6 +3,7 @@
 namespace NewspackCustomContentMigrator\Logic;
 
 use \WP_CLI;
+use WP_Error;
 
 class Attachments {
 	/**
@@ -53,6 +54,11 @@ class Attachments {
 			$tmpfname = wp_tempnam( $path );
 			copy( $path, $tmpfname );
 		}
+
+		if ( ! file_exists( $tmpfname ) || filesize( $tmpfname ) < 1 ) {
+			return new WP_Error( sprintf( 'File %s was not found or it was empty', $path ) );
+		}
+
 		$file_array = [
 			'name'     => wp_basename( $path ),
 			'tmp_name' => $tmpfname,
@@ -66,6 +72,12 @@ class Attachments {
 			if ( ! empty ( $probably_extension ) ) {
 				$file_array['name'] .= '.' . $probably_extension;
 			}
+		}
+
+		$maybe_exising_attachment_id = $this->maybe_get_exisiting_attachment_id( $file_array['tmp_name'], $file_array['name'] );
+		if ( null !== $maybe_exising_attachment_id ) {
+			@unlink( $file_array['tmp_name'] );
+			return $maybe_exising_attachment_id;
 		}
 
 		if ( $title ) {
@@ -91,6 +103,44 @@ class Attachments {
 		}
 
 		return $att_id;
+	}
+
+	/**
+	 * @param string $filepath
+	 * @param string $filename
+	 *
+	 * @return int|null Attachment ID if found, null otherwise.
+	 */
+	public function maybe_get_exisiting_attachment_id( $filepath, $filename = '' ): int|null {
+		if ( ! file_exists( $filepath ) ) {
+			return null;
+		}
+
+		if ( empty( $filename ) ) {
+			$filename = basename( $filepath );
+		}
+		global $wpdb;
+		$like = '%' . $wpdb->esc_like( $filename );
+		$sql  = $wpdb->prepare(
+			"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attached_file' AND meta_value LIKE '%s'",
+			$like
+		);
+
+		foreach ( $wpdb->get_col( $sql ) as $attachment_id ) {
+
+			$candidate_path = get_attached_file( $attachment_id );
+			// Check the file sizes first. It's a fast operation and will save us from having to do the md5 check.
+			if ( ! file_exists( $candidate_path ) || ( filesize( $candidate_path ) !== filesize( $filepath ) ) ) {
+				continue;
+			}
+
+			if ( md5_file( $candidate_path ) === md5_file( $filepath ) ) {
+				return $attachment_id;
+			}
+
+		}
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
This adds a function that checks if we already have an upload to the media library of a given file.
The file to check needs to be in the filesystem (like we don with tmp files in `import_external_file()` in `Attachments.php`).

The idea is to check if we already have a file uploaded by getting file(s) from the media library with the same filename and then checking to see if a file has:
* The same file size 
* The same hash of the file content

We talked about this one in Slack: p1693569468634049-slack-C013N9S2C7Q