### PR TITLE
Mustang News: Command to move image credit from posts to attachments

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -84,5 +84,6 @@ PluginSetup::register_migrators(
 		Command\PublisherSpecific\DallasExaminerMigrator::class,
 		Command\PublisherSpecific\BenitoLinkMigrator::class,
 		Command\PublisherSpecific\EfectoCocuyoContentMigrator::class,
+		Command\PublisherSpecific\MustangNewsMigrator::class,
 	)
 );


### PR DESCRIPTION
- [x] We need to clean up the class inclusion in newspack-custom-content-migrator.php once the command has been run.