### PR TITLE
Do not always install WP importer

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -23,7 +23,6 @@ require_once ABSPATH . 'wp-settings.php';
 
 PluginSetup::configure_error_reporting();
 PluginSetup::register_ticker();
-PluginSetup::setup_wordpress_importer();
 PluginSetup::register_migrators(
 	array(
 		// General.

--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://newspack.blog/
  * Author:      Automattic
  * Author URI:  https://newspack.blog/
- * Version:     1.5.0
+ * Version:     1.5.1
  *
  * @package  Newspack_Custom_Content_Migrator
  */


### PR DESCRIPTION
Super simple PR -- removes one line from main plugin file.

WP Importer should not always be installed and activated every time this plugin is used.