### PR TITLE
Capital B and Lede Authors custom plugin migrator

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://newspack.blog/
  * Author:      Automattic
  * Author URI:  https://newspack.blog/
- * Version:     1.5.1
+ * Version:     1.5.2
  *
  * @package  Newspack_Custom_Content_Migrator
  */

--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -65,6 +65,7 @@ PluginSetup::register_migrators(
 		Command\General\UsersMigrator::class,
 		Command\General\EmbarcaderoMigrator::class,
 		Command\General\ChorusCmsMigrator::class,
+		Command\General\LedeMigrator::class,
 
 		// Publisher specific, remove when launched.
 		Command\PublisherSpecific\GadisMigrator::class,

--- a/src/Command/General/LedeMigrator.php
+++ b/src/Command/General/LedeMigrator.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Command\General;
+
+use \NewspackCustomContentMigrator\Command\InterfaceCommand;
+use \NewspackCustomContentMigrator\Logic\CoAuthorPlus;
+use \WP_CLI;
+
+class LedeMigrator implements InterfaceCommand {
+
+	/**
+	 * @var null|InterfaceCommand Instance.
+	 */
+	private static $instance = null;
+
+	/**
+	 * CoAuthorPlus instance.
+	 *
+	 * @var CoAuthorPlus CoAuthorPlus instance.
+	 */
+	private $cap;
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->cap = new CoAuthorPlus();
+	}
+
+	/**
+	 * Singleton get_instance().
+	 *
+	 * @return InterfaceCommand|null
+	 */
+	public static function get_instance() {
+		$class = get_called_class();
+		if ( null === self::$instance ) {
+			self::$instance = new $class;
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * See InterfaceCommand::register_commands.
+	 */
+	public function register_commands() {
+		WP_CLI::add_command( 'newspack-content-migrator lede-migrate-authors-to-gas',
+			[ $this, 'cmd_migrate_authors_to_gas' ],
+			[
+				'shortdesc' => 'Migrates that custom Lede Authors plugin data to GA authors.',
+			]
+		);
+	}
+
+	/**
+	 * Callable for `newspack-content-migrator lede-migrate-authors-to-gas` command.
+	 *
+	 * @param array $pos_args
+	 * @param array $assoc_args
+	 */
+	public function cmd_migrate_authors_to_gas( $pos_args, $assoc_args ) {
+
+		// Create all GAs.
+		global $wpdb;
+		// Live https://atlanta.capitalbnews.org/cop-city-unrest/
+		// Staging ID 3395
+		//      Madeline Thigpen
+		//      Adam Mahoney
+		// Get all post_type = 'profile'.
+		$profile_posts_rows = $wpdb->get_results( "SELECT * FROM {$wpdb->posts} WHERE post_type = 'profile';", ARRAY_A );
+		if ( empty( $profile_posts_rows ) ) {
+			WP_CLI::error( "No objects of post_type = 'profile' found. Looks like the 'custom Lede authors plugin' was not used on this site." );
+		}
+		foreach ( $profile_posts_rows as $profile_post_row ) {
+			$ga_args = [];
+
+			if ( empty( $profile_post_row['post_title'] ) ) {
+				// Log warning
+				$d=1;
+			}
+
+			// Get author data available from wp_posts.
+			$ga_args['display_name'] = $profile_post_row['post_title'];
+			if ( ! empty( $profile_post_row['post_content'] ) ) {
+				$ga_args['description'] = $profile_post_row['post_content'];
+			}
+			if ( ! empty( $profile_post_row['post_name'] ) ) {
+				$ga_args['user_login'] = $profile_post_row['post_name'];
+			}
+
+			// Get author data available from wp_postmeta.
+			$profile_postmeta_rows = $wpdb->get_results( "SELECT * FROM {$wpdb->postmeta} WHERE post_id = {$profile_post_row['ID']};", ARRAY_A );
+			$social_links = [];
+			foreach ( $profile_postmeta_rows as $profile_postmeta_row ) {
+
+				// user_login might also be stored as postmeta. Override if exists.
+				if ( 'user_login' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					$ga_args['user_login'] = $profile_postmeta_row['meta_value'];
+				}
+
+				// Email might be stored as two different metas.
+				if ( 'user_email' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					$ga_args['user_email'] = $profile_postmeta_row['meta_value'];
+				}
+				if ( 'email' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					$ga_args['user_email'] = $profile_postmeta_row['meta_value'];
+				}
+
+				// Short bio might also be stored as short_bio meta_key. Append it to description after line break.
+				if ( 'short_bio' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					$ga_args['description'] .= ! empty( $ga_args['description'] ) ? "\n" : '';
+					$ga_args['description'] .= $profile_postmeta_row['meta_value'];
+				}
+
+				if ( 'first_name' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					$ga_args['first_name'] = $profile_postmeta_row['meta_value'];
+				}
+				if ( 'last_name' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					$ga_args['last_name'] = $profile_postmeta_row['meta_value'];
+				}
+
+				// Avatar.
+				if ( '_thumbnail_id' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					$ga_args['avatar'] = $profile_postmeta_row['meta_value'];
+				}
+
+				// There could also be a linked WP_User ID.
+				$linked_wp_user_id = null;
+				if ( 'user_id' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					// Confirm that WP_User exists.
+					$user_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->users} WHERE ID = %d;", $profile_postmeta_row['meta_value'] ) );
+					if ( $user_id ) {
+						$linked_wp_user_id = $user_id;
+					}
+				}
+
+				// Get additional social links.
+				if ( 'twitter' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+					$social_links[] = '<a href="' . $profile_postmeta_row['meta_value'] . '" $social_links>Twitter @' . $profile_postmeta_row['meta_value'] . '</a>';
+				}
+			}
+
+			// Simply append social links to the description.
+			if ( ! empty( $social_links ) ) {
+				$ga_args['description'] .= ! empty( $ga_args['description'] ) ? ' ' : '';
+				$ga_args['description'] .= implode( ' ', $social_links );
+			}
+
+
+			// Before creating, check if GA already exists.
+
+
+			$ga_id = $this->cap->create_guest_author( $ga_args );
+			// Handle error.
+
+			// Link WP_User.
+			if ( $linked_wp_user_id ) {
+				$wp_user = get_user_by( 'ID', $linked_wp_user_id );
+				$this->cap->link_guest_author_to_wp_user( $ga_id, $wp_user );
+			}
+		}
+
+
+		// Assign GAs to posts.
+	}
+}

--- a/src/Command/General/LedeMigrator.php
+++ b/src/Command/General/LedeMigrator.php
@@ -91,10 +91,30 @@ class LedeMigrator implements InterfaceCommand {
 	 *
 	 * @param array $pos_args   Positional arguments.
 	 * @param array $assoc_args Associative arguments.
+	 *
+	 * @throws \RuntimeException If required live tables don't exist.
 	 */
 	public function cmd_migrate_authors_to_gas( array $pos_args, array $assoc_args ) {
+		global $wpdb;
 
+		// Get args.
 		$live_table_prefix = $assoc_args['live-table-prefix'];
+
+		/**
+		 * Validate that live tables posts and postmeta exist.
+		 */
+		$live_posts_table    = esc_sql( $live_table_prefix . 'posts' );
+		$live_postmeta_table = esc_sql( $live_table_prefix . 'postmeta' );
+		// phpcs:ignore -- Table name properly escaped.
+		$test_var = $wpdb->get_var( "select 1 from $live_posts_table;" );
+		if ( ! $test_var ) {
+			throw new \RuntimeException( sprintf( 'Table %s not found -- needed to access original Lede Author data.', $live_posts_table ) );
+		}
+		// phpcs:ignore -- Table name properly escaped.
+		$test_var = $wpdb->get_var( "select 1 from $live_postmeta_table;" );
+		if ( ! $test_var ) {
+			throw new \RuntimeException( sprintf( 'Table %s not found -- needed to access original Lede Author data.', $live_postmeta_table ) );
+		}
 
 		WP_CLI::line( 'Converting Lede Authors profiles to GAs and assigning them to all posts...' );
 		// $post_ids = $this->posts->get_all_posts_ids();

--- a/src/Command/General/LedeMigrator.php
+++ b/src/Command/General/LedeMigrator.php
@@ -101,7 +101,7 @@ class LedeMigrator implements InterfaceCommand {
 
 		global $wpdb;
 
-		// Validate that live tables posts and postmeta exist.
+		// Validate that required live tables exist. Needed to access original IDs of author Post objects, terms and WP_Users -- because these IDs might get changed when imported on top of an existing site. Future improvement -- switch to fetching original ID from DB, however we need to implement saving imported WP_User's original ID in DB first.
 		$this->validate_tables_exist( [ $live_table_prefix . 'posts', $live_table_prefix . 'postmeta', $live_table_prefix . 'users', $live_table_prefix . 'usermeta' ] );
 
 		WP_CLI::line( 'Converting Lede Authors profiles to GAs and assigning them to all posts...' );

--- a/src/Command/General/LedeMigrator.php
+++ b/src/Command/General/LedeMigrator.php
@@ -95,10 +95,11 @@ class LedeMigrator implements InterfaceCommand {
 	 * @throws \RuntimeException If required live tables don't exist.
 	 */
 	public function cmd_migrate_authors_to_gas( array $pos_args, array $assoc_args ) {
-		global $wpdb;
 
-		// Get args.
+		// Args.
 		$live_table_prefix = $assoc_args['live-table-prefix'];
+
+		global $wpdb;
 
 		/**
 		 * Validate that live tables posts and postmeta exist.
@@ -117,10 +118,8 @@ class LedeMigrator implements InterfaceCommand {
 		}
 
 		WP_CLI::line( 'Converting Lede Authors profiles to GAs and assigning them to all posts...' );
-		// $post_ids = $this->posts->get_all_posts_ids();
-		$post_ids = [ 640615 ];
+		$post_ids = $this->posts->get_all_posts_ids();
 		foreach ( $post_ids as $key_post_id => $post_id ) {
-
 			WP_CLI::log( sprintf( '(%d)/(%d) %d', $key_post_id + 1, count( $post_ids ), $post_id ) );
 
 			$ga_ids = $this->lede->convert_lede_authors_to_gas_for_post( $live_table_prefix, $post_id );

--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -2735,6 +2735,8 @@ class ContentDiffMigrator {
 	 * @return int Inserted User ID.
 	 */
 	public function insert_user( $user_row ) {
+		$old_user_id = $user_row['ID'];
+
 		$insert_user_row = $user_row;
 		unset( $insert_user_row['ID'] );
 
@@ -2742,6 +2744,19 @@ class ContentDiffMigrator {
 		if ( 1 != $inserted ) {
 			throw new \RuntimeException( sprintf( 'Error inserting user, ID %d, user_row %s', $user_row['ID'], json_encode( $user_row ) ) );
 		}
+
+		// Last inserted ID.
+		$new_user_id = $this->wpdb->insert_id;
+
+		// Save original user ID as usermeta.
+		$this->wpdb->insert(
+			$this->wpdb->usermeta,
+			[
+				'user_id'    => $new_user_id,
+				'meta_key'   => self::SAVED_META_LIVE_POST_ID,
+				'meta_value' => $old_user_id,
+			]
+		);
 
 		return $this->wpdb->insert_id;
 	}

--- a/src/Logic/Lede.php
+++ b/src/Logic/Lede.php
@@ -112,11 +112,11 @@ class Lede {
 
 		// Get existing GA.
 		$result = $this->cap->get_guest_author_by_display_name( $text );
-		if ( 1 == count( $result ) ) {
+		if ( $result && is_object( $result ) ) {
 			$ga_id = $result->ID;
 
 			return $ga_id;
-		} elseif ( count( $result ) > 1 ) {
+		} elseif ( $result && is_array( $result ) && count( $result ) > 1 ) {
 			$ga_id = $result[0]->ID;
 
 			return $ga_id;
@@ -188,6 +188,9 @@ class Lede {
 
 			// Short bio can be stored as short_bio meta_key. Append it to description with a double line break.
 			if ( 'short_bio' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				if ( ! isset( $ga_args['description'] ) ) {
+					$ga_args['description'] = '';
+				}
 				$ga_args['description'] .= ! empty( $ga_args['description'] ) ? "\n\n" : '';
 				$ga_args['description'] .= $profile_postmeta_row['meta_value'];
 			}

--- a/src/Logic/Lede.php
+++ b/src/Logic/Lede.php
@@ -27,6 +27,13 @@ class Lede {
 	private $cap;
 
 	/**
+	 * Posts instance.
+	 *
+	 * @var Posts Posts instance.
+	 */
+	private $posts;
+
+	/**
 	 * Logger instance.
 	 *
 	 * @var Logger Logger instance.

--- a/src/Logic/Lede.php
+++ b/src/Logic/Lede.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Logic;
+
+use \NewspackCustomContentMigrator\Logic\CoAuthorPlus;
+use \NewspackCustomContentMigrator\Logic\Posts;
+use \NewspackCustomContentMigrator\Utils\Logger;
+
+/**
+ * Lede migration logic.
+ */
+class Lede {
+
+	/**
+	 * This script knows how to convert following byline types. Add more if encountered.
+	 */
+	const KNOWN_LEDE_AUTHOR_BYLINE_TYPES = [
+		'byline_id',
+		'text',
+	];
+
+	/**
+	 * CoAuthorPlus instance.
+	 *
+	 * @var CoAuthorPlus CoAuthorPlus instance.
+	 */
+	private $cap;
+
+	/**
+	 * Logger instance.
+	 *
+	 * @var Logger Logger instance.
+	 */
+	private $logger;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->cap    = new CoAuthorPlus();
+		$this->posts  = new Posts();
+		$this->logger = new Logger();
+	}
+
+	/**
+	 * Converts Lede Authors to GA authors for a single post.
+	 *
+	 * @param string $live_table_prefix Live tables prefix. Needed to access live_posts and live_postmeta.
+	 * @param int    $post_id           Post ID.
+	 *
+	 * @throws \RuntimeException If required live tables don't exist.
+	 *
+	 * @return array|null GA IDs.
+	 */
+	public function convert_lede_authors_to_gas_for_post( $live_table_prefix, $post_id ) {
+		global $wpdb;
+
+		/**
+		 * Validate that tables live_posts and live_postmeta exist.
+		 */
+		$live_posts_table    = esc_sql( $live_table_prefix . 'posts' );
+		$live_postmeta_table = esc_sql( $live_table_prefix . 'postmeta' );
+		// phpcs:ignore -- Table name properly escaped.
+		$test_var = $wpdb->get_var( "select 1 from $live_posts_table;" );
+		if ( ! $test_var ) {
+			throw new \RuntimeException(
+				sprintf(
+					'Table %s not found -- needed to access original Lede Author data.',
+					$live_posts_table
+				)
+			);
+		}
+		// phpcs:ignore -- Table name properly escaped.
+		$test_var = $wpdb->get_var( "select 1 from $live_postmeta_table;" );
+		if ( ! $test_var ) {
+			throw new \RuntimeException( sprintf( 'Table %s not found -- needed to access original Lede Author data.', $live_postmeta_table ) );
+		}
+
+
+		/**
+		 * Get this post's byline postmeta.
+		 */
+		// phpcs:ignore -- Table name properly escaped.
+		$byline_postmeta_row = $wpdb->get_row( "select * from {$wpdb->postmeta} where meta_key = 'byline' and post_id = %d ;", $post_id );
+		if ( empty( $byline_postmeta_row ) ) {
+			return null;
+		}
+
+		$byline_meta = unserialize( $byline_postmeta_row[0]['meta_value'] );
+		foreach ( $byline_meta['profiles'] as $profile ) {
+			$type = $profile['type'];
+
+			// Check if script knows how to convert this byline type.
+			if ( ! in_array( $type, self::KNOWN_LEDE_AUTHOR_BYLINE_TYPES ) ) {
+				throw new \RuntimeException( sprintf( "Byline type '$type' is unknown. See self::KNOWN_LEDE_AUTHOR_BYLINE_TYPES and write more code to convert this byline type to GA." ) );
+			}
+
+			// Convert byline to GAs.
+			$ga_ids = [];
+			switch ( $type ) {
+				case 'byline_id':
+					// Unserialized data expects to contain 'term_id' and 'post_id'.
+					$term_id  = $profile['type']['atts']['term_id'] ?? null;
+					$post_id  = $profile['type']['atts']['post_id'] ?? null;
+					$ga_id    = $this->convert_byline_id_author_profile_type_to_ga( $live_table_prefix, $term_id, $post_id );
+					$ga_ids[] = $ga_id;
+					break;
+
+				case 'text':
+					// Unserialized data is only expected to have 'text', i.e. display_name.
+					$text     = $profile['type']['atts']['text'] ?? null;
+					$ga_id    = $this->convert_text_author_profile_type_to_ga( $text );
+					$ga_ids[] = $ga_id;
+					break;
+			}
+		}
+
+		// Finally assign GAs to the post.
+		if ( $ga_ids ) {
+			$this->cap->assign_guest_authors_to_post( $ga_ids, $post_id, $append_to_existing_users = false );
+		}
+
+		return $ga_ids;
+	}
+
+	/**
+	 * Converts Lede Author byline of type 'text' to GA.
+	 *
+	 * @param string $text Text inside byline data, which is author's display name.
+	 *
+	 * @return int GA ID, existing or newly created.
+	 */
+	public function convert_text_author_profile_type_to_ga( $text ) {
+
+		// Get existing GA.
+		$result = $this->cap->get_guest_author_by_display_name( $text );
+		if ( 1 == count( $result ) ) {
+			$ga_id = $result->ID;
+
+			return $ga_id;
+		} elseif ( count( $result ) > 1 ) {
+			$ga_id = $result[0]->ID;
+
+			return $ga_id;
+		}
+
+		// Create GA.
+		$ga_id = $this->cap->create_guest_author( [ 'display_name' => $text ] );
+
+		return $ga_id;
+	}
+
+	/**
+	 * Converts Lede Author byline of type 'profile' to GA.
+	 *
+	 * @param string $live_table_prefix Live tables prefix. Needed to access live_posts and live_postmeta.
+	 * @param int    $term_id              Not really used because we seem to be finding all the info in author $post_id.
+	 * @param int    $post_id              Author post ID.
+	 *
+	 * @throws \RuntimeException If GA wasn't created successfully.
+	 *
+	 * @return int|null GA ID, existing or newly created.
+	 */
+	public function convert_byline_id_author_profile_type_to_ga( $live_table_prefix, $term_id, $post_id ) {
+		global $wpdb;
+
+		$live_posts_table = esc_sql( $live_table_prefix . 'posts' );
+		// phpcs:ignore -- Table name properly escaped.
+		$profile_post_row = $wpdb->get_row( $wpdb->prepare( "select * from {$live_posts_table} where ID = %d;", $post_id ) );
+		if ( empty( $profile_post_row ) ) {
+			return null;
+		}
+
+		// post_title is mandatory.
+		if ( empty( $profile_post_row['post_title'] ) ) {
+			return null;
+		}
+
+		// GA creation array.
+		$ga_args      = [];
+		$social_links = [];
+
+		// Get author data available from wp_posts.
+		$ga_args['display_name'] = $profile_post_row['post_title'];
+		if ( ! empty( $profile_post_row['post_content'] ) ) {
+			$ga_args['description'] = $profile_post_row['post_content'];
+		}
+		if ( ! empty( $profile_post_row['post_name'] ) ) {
+			$ga_args['user_login'] = $profile_post_row['post_name'];
+		}
+
+		// Get author data from wp_postmeta.
+		// phpcs:ignore -- Table name properly escaped.
+		$profile_postmeta_rows = $wpdb->get_results( "SELECT * FROM {$live_posts_table} WHERE post_id = {$profile_post_row['ID']};", ARRAY_A );
+		foreach ( $profile_postmeta_rows as $profile_postmeta_row ) {
+
+			// user_login can be stored as postmeta. Use it if exists.
+			if ( 'user_login' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$ga_args['user_login'] = $profile_postmeta_row['meta_value'];
+			}
+
+			// Email might be stored as two different metas.
+			if ( 'user_email' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$ga_args['user_email'] = $profile_postmeta_row['meta_value'];
+			}
+			if ( 'email' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$ga_args['user_email'] = $profile_postmeta_row['meta_value'];
+			}
+
+			// Short bio can be stored as short_bio meta_key. Append it to description with a double line break.
+			if ( 'short_bio' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$ga_args['description'] .= ! empty( $ga_args['description'] ) ? "\n\n" : '';
+				$ga_args['description'] .= $profile_postmeta_row['meta_value'];
+			}
+
+			if ( 'first_name' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$ga_args['first_name'] = $profile_postmeta_row['meta_value'];
+			}
+			if ( 'last_name' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$ga_args['last_name'] = $profile_postmeta_row['meta_value'];
+			}
+
+			// Avatar.
+			if ( '_thumbnail_id' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$ga_args['avatar'] = $profile_postmeta_row['meta_value'];
+			}
+
+			// Linked WP_User ID.
+			$linked_wp_user_id = null;
+			if ( 'user_id' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$linked_wp_user_id = $profile_postmeta_row['meta_value'];
+			}
+
+			// Get additional social links.
+			if ( 'twitter' == $profile_postmeta_row['meta_key'] && ! empty( $profile_postmeta_row['meta_value'] ) ) {
+				$handle         = $profile_postmeta_row['meta_value'];
+				$social_links[] = sprintf( '<a href="https://twitter.com/%s" target="_blank">Twitter @%s</a>', $handle, $handle );
+			}
+		}
+
+		// Append social links to the description.
+		if ( ! empty( $social_links ) ) {
+			$ga_args['description'] .= ! empty( $ga_args['description'] ) ? ' ' : '';
+			$ga_args['description'] .= implode( ' ', $social_links );
+		}
+
+		// Check if GA already exists.
+		$ga_id = null;
+		if ( isset( $ga_args['user_login'] ) && ! empty( $ga_args['user_login'] ) ) {
+			$ga    = $this->cap->get_guest_author_by_user_login( $ga_args['user_login'] );
+			$ga_id = $ga ? $ga->ID : null;
+		} else {
+			$ga    = $this->cap->get_guest_author_by_display_name( $ga_args['display_name'] );
+			$ga_id = $ga ? $ga->ID : null;
+		}
+		if ( $ga_id ) {
+			return $ga_id;
+		}
+
+		// Create GA.
+		$ga_id = $this->cap->create_guest_author( $ga_args );
+		if ( ! $ga_id ) {
+			throw new \RuntimeException( sprintf( 'create_guest_author() did not return ga_id, ga_args:%s', json_encode( $ga_args ) ) );
+		}
+
+		// Link WP_User.
+		if ( $linked_wp_user_id ) {
+			$wp_user = get_user_by( 'ID', $linked_wp_user_id );
+			if ( $wp_user ) {
+				$this->cap->link_guest_author_to_wp_user( $ga_id, $wp_user );
+			}
+		}
+
+		return $ga_id;
+	}
+
+}


### PR DESCRIPTION
Lede custom Authors migrator to GAs:
- a command `lede-migrate-authors-to-gas`, which also takes `--live-table-prefix` argument (value e.g. `live_`), because it needs to know which were the old IDs of Posts **and Users**

Content Diff, slipped in a connected small addition:
- added saving meta "old ID" for imported WP_Users