### PR TITLE
Load publishers conditionally based on PHP version

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -87,3 +87,15 @@ PluginSetup::register_migrators(
 		Command\PublisherSpecific\TheEmancipatorMigrator::class,
 	)
 );
+
+if ( str_starts_with( phpversion(), '8' ) ) {
+	// The array is keyed with the prefix the class tends to use on commands.
+	// We could load only one publisher at if we wanted to at a later time, but this is good for now.
+	$publishers_on_8 = [
+		'emancipator' => Command\PublisherSpecific\TheEmancipatorMigrator::class,
+	];
+
+	if ( ! empty( $publishers_on_8 ) ) {
+		PluginSetup::register_migrators( $publishers_on_8 );
+	}
+}


### PR DESCRIPTION
This is a small attempt to make it possible for us to use PHP8 on publishers while still keeping PHP7 compatibility in the plugin. I added a conditional where PHP8 publishers can be added.

## How to test
* Run `wp newspack-content-migrator emancipator-list-content-refresh` (it does nothing other than list commands, so it's safe). If it loads correctly (and your env is on PHP 8) we are good. For extra points, also test on a PHP 7  site and verify that the command would not work.

---

- [x] confirmed that PHPCS has been run
