### PR TITLE
Fix/moving content from a category to another

### DIFF
--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -379,10 +379,10 @@ class TaxonomyMigrator implements InterfaceCommand {
 		// Check IDs.
 		$source_term      = get_term( $source_term_id, $taxonomy );
 		$destination_term = get_term( $destination_term_id, $taxonomy );
-		if ( is_null( $source_term ) ) {
+		if ( ! $source_term instanceof \WP_Term ) {
 			WP_CLI::error( 'Wrong source term ID.' );
 		}
-		if ( is_null( $destination_term ) ) {
+		if ( ! $destination_term instanceof \WP_Term ) {
 			WP_CLI::error( 'Wrong destination term ID.' );
 		}
 		if ( $source_term_id == $destination_term_id ) {

--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -302,26 +302,26 @@ class TaxonomyMigrator implements InterfaceCommand {
 				'shortdesc' => 'Splits duplicate term slugs into separate terms.',
 				'synopsis'  => [
 					[
-						'type'          => 'flag',
-						'name'          => 'display',
-						'description'   => 'Display the terms that will be split only. No further execution nor changes will be made.',
-						'optional'      => true,
-						'repeating'     => false,
+						'type'        => 'flag',
+						'name'        => 'display',
+						'description' => 'Display the terms that will be split only. No further execution nor changes will be made.',
+						'optional'    => true,
+						'repeating'   => false,
 					],
 					[
-						'type'          => 'flag',
-						'name'          => 'interactive',
-						'description'   => 'Ask for confirmation before proceeding with any change.',
-						'optional'      => true,
-						'repeating'     => false,
+						'type'        => 'flag',
+						'name'        => 'interactive',
+						'description' => 'Ask for confirmation before proceeding with any change.',
+						'optional'    => true,
+						'repeating'   => false,
 					],
 					[
-						'type'          => 'flag',
-						'name'          => 'show-taxonomies',
-						'description'   => 'Show the taxonomies for each term.',
-						'optional'      => true,
-						'repeating'     => false,
-						'default'       => false,
+						'type'        => 'flag',
+						'name'        => 'show-taxonomies',
+						'description' => 'Show the taxonomies for each term.',
+						'optional'    => true,
+						'repeating'   => false,
+						'default'     => false,
 					],
 				],
 			]
@@ -635,11 +635,11 @@ class TaxonomyMigrator implements InterfaceCommand {
 
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT 
-       				term_taxonomy_id, 
-       				term_id 
-				FROM $wpdb->term_taxonomy 
-				WHERE taxonomy = 'post_tag' 
+				"SELECT
+       				term_taxonomy_id,
+       				term_id
+				FROM $wpdb->term_taxonomy
+				WHERE taxonomy = 'post_tag'
 				  AND count <= %d",
 				$tag_limit
 			)
@@ -670,14 +670,14 @@ class TaxonomyMigrator implements InterfaceCommand {
 
 			$term_ids           = implode( ',', $term_ids );
 			$affected_term_rows = $wpdb->get_results(
-				"SELECT 
-                    t.term_id, 
+				"SELECT
+                    t.term_id,
                     COUNT(tt.term_taxonomy_id) as counter
-				FROM $wpdb->terms t 
-				    LEFT JOIN $wpdb->term_taxonomy tt 
-				        ON t.term_id = tt.term_id 
-				WHERE t.term_id IN ($term_ids) 
-				GROUP BY t.term_id 
+				FROM $wpdb->terms t
+				    LEFT JOIN $wpdb->term_taxonomy tt
+				        ON t.term_id = tt.term_id
+				WHERE t.term_id IN ($term_ids)
+				GROUP BY t.term_id
 				HAVING counter = 0"
 			);
 
@@ -713,25 +713,25 @@ class TaxonomyMigrator implements InterfaceCommand {
 		global $wpdb;
 
 		return $wpdb->get_results(
-			"SELECT 
-	            tt.term_taxonomy_id, 
+			"SELECT
+	            tt.term_taxonomy_id,
        			t.term_id,
        			t.name,
        			t.slug,
        			tt.taxonomy,
-	            tt.count, 
-	            sub.counter 
+	            tt.count,
+	            sub.counter
 			FROM $wpdb->term_taxonomy tt LEFT JOIN (
-			    SELECT 
-			           term_taxonomy_id, 
-			           COUNT(object_id) as counter 
-			    FROM $wpdb->term_relationships 
+			    SELECT
+			           term_taxonomy_id,
+			           COUNT(object_id) as counter
+			    FROM $wpdb->term_relationships
 			    GROUP BY term_taxonomy_id
-			    ) as sub 
-			ON tt.term_taxonomy_id = sub.term_taxonomy_id 
+			    ) as sub
+			ON tt.term_taxonomy_id = sub.term_taxonomy_id
 			LEFT JOIN $wpdb->terms t ON t.term_id = tt.term_id
-			WHERE sub.counter IS NOT NULL 
-			  AND tt.count <> sub.counter 
+			WHERE sub.counter IS NOT NULL
+			  AND tt.count <> sub.counter
 			  AND tt.taxonomy IN ('category', 'post_tag')"
 		);
 	}
@@ -1205,8 +1205,8 @@ class TaxonomyMigrator implements InterfaceCommand {
 	public function delete_loose_terms( array $term_ids = [] ) {
 		global $wpdb;
 		$imploded_term_ids  = implode( ', ', $term_ids );
-		$loose_term_ids_sql = "SELECT t.term_id, wtt.term_taxonomy_id FROM $wpdb->terms t 
-    		LEFT JOIN $wpdb->term_taxonomy wtt on t.term_id = wtt.term_id 
+		$loose_term_ids_sql = "SELECT t.term_id, wtt.term_taxonomy_id FROM $wpdb->terms t
+    		LEFT JOIN $wpdb->term_taxonomy wtt on t.term_id = wtt.term_id
 			WHERE t.term_id IN ( $imploded_term_ids ) AND wtt.term_taxonomy_id IS NULL";
 		$this->output_sql( $loose_term_ids_sql );
 		$loose_term_ids = $wpdb->get_results( $loose_term_ids_sql );

--- a/src/Command/PublisherSpecific/CCMMigrator.php
+++ b/src/Command/PublisherSpecific/CCMMigrator.php
@@ -767,7 +767,7 @@ class CCMMigrator implements InterfaceCommand {
 			}
 
 
-			$this->taxonomy_logic->reassign_all_content_from_one_category_to_another( $source_term_id, $destination_term_id );
+			$this->taxonomy_logic->reassign_all_content_from_one_taxonomy_to_another( 'category', $source_term_id, $destination_term_id );
 
 			// Update category count.
 			$this->update_counts_for_taxonomies( $this->get_unsynced_taxonomy_rows() );

--- a/src/Logic/Taxonomy.php
+++ b/src/Logic/Taxonomy.php
@@ -138,9 +138,9 @@ class Taxonomy {
 
 		$existing_term_id = $wpdb->get_var(
 			$wpdb->prepare(
-				"select t.term_id 
+				"select t.term_id
 					from {$wpdb->terms} t
-					join {$wpdb->term_taxonomy} tt on tt.term_id = t.term_id 
+					join {$wpdb->term_taxonomy} tt on tt.term_id = t.term_id
 					where tt.taxonomy = %s and t.name = %s and tt.parent = %d;",
 				$taxonomy,
 				htmlentities( $name ),
@@ -177,9 +177,9 @@ class Taxonomy {
 		if ( 0 != $cat_parent_id ) {
 			$existing_cat_parent_id = $wpdb->get_var(
 				$wpdb->prepare(
-					"select t.term_id 
+					"select t.term_id
 						from {$wpdb->terms} t
-						join {$wpdb->term_taxonomy} tt on tt.term_id = t.term_id 
+						join {$wpdb->term_taxonomy} tt on tt.term_id = t.term_id
 						where tt.taxonomy = 'category' and tt.term_id = %d;",
 					$cat_parent_id
 				)
@@ -209,12 +209,12 @@ class Taxonomy {
 		global $wpdb;
 
 		return $wpdb->get_results(
-			"SELECT 
-			t.slug, 
+			"SELECT
+			t.slug,
 			GROUP_CONCAT( DISTINCT tt.taxonomy ORDER BY tt.taxonomy SEPARATOR ', ' ) as taxonomies,
-			GROUP_CONCAT( 
-			    CONCAT( tt.term_id, ':', tt.term_taxonomy_id, ':', tt.taxonomy ) 
-			    ORDER BY t.term_id, tt.term_taxonomy_id ASC SEPARATOR '  |  ' 
+			GROUP_CONCAT(
+			    CONCAT( tt.term_id, ':', tt.term_taxonomy_id, ':', tt.taxonomy )
+			    ORDER BY t.term_id, tt.term_taxonomy_id ASC SEPARATOR '  |  '
 			    ) as 'term_id:term_taxonomy_id:taxonomy',
 			COUNT( DISTINCT tt.term_taxonomy_id ) as term_taxonomy_id_count
 			FROM $wpdb->terms t
@@ -236,21 +236,21 @@ class Taxonomy {
 	public function get_terms_and_taxonomies_by_slug( string $slug, array $taxonomies = [ 'category', 'post_tag' ] ) {
 		global $wpdb;
 
-		$query = "SELECT 
-	                t.term_id, 
-	                t.name, t.slug, 
-	                tt.term_taxonomy_id, 
-	                tt.taxonomy, 
-	                tt.parent, 
-	                tt.count 
+		$query = "SELECT
+	                t.term_id,
+	                t.name, t.slug,
+	                tt.term_taxonomy_id,
+	                tt.taxonomy,
+	                tt.parent,
+	                tt.count
 				FROM $wpdb->terms t
 				INNER JOIN $wpdb->term_taxonomy tt ON t.term_id = tt.term_id
 				WHERE t.slug = %s";
 
 		if ( ! empty( $taxonomies ) ) {
 			$query .= 'AND tt.taxonomy IN ( '
-			          . implode(',', array_fill( 0, count( $taxonomies ), '%s' ) )
-			          . ' )';
+					  . implode( ',', array_fill( 0, count( $taxonomies ), '%s' ) )
+					  . ' )';
 		}
 
 		$query .= ' ORDER BY t.term_id, tt.term_taxonomy_id ASC';


### PR DESCRIPTION
## How to test
- Create two categories "Source Category", and "Destination Category".
- Create Three posts, one for each category, and the third for both categories.
- Run the command to move posts from the "Source Category" to the "Destination Category": `wp newspack-content-migrator move-content-from-one-category-to-another --source-term-id=123 --destination-term-id=456`
- Notice the SQL error and that the posts were not moved.
- Switch to this branch and re-run the command.
- Notice The Source Category with no posts, and all the posts were moved to the Destination Category.

Play a bit more with it 😅 

---

- [x] confirmed that PHPCS has been run
