### PR TITLE
Remove breaking exit

### DIFF
--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -594,10 +594,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			}
 
 			$this->logger->log( self::LOG_FILE, sprintf( 'Imported post %d/%d: %d with the ID %d', $post_index + 1, count( $posts ), $post['story_id'], $wp_post_id ), Logger::SUCCESS );
-
-			if ( 2000 === $post_index ) {
-				break;
-			}
 		}
 	}
 


### PR DESCRIPTION
The main import command `cmd_embarcadero_import_posts_content` uses optional `--index-from` and `--index-to` arguments. If these are omitted command should import all the records (useful if running on local). If these optional arguments are used, [these lines](https://github.com/Automattic/newspack-custom-content-migrator/pull/356/files#diff-63741758e19aeef0bc3caad7975625f46c2000cc08706d5e639bf97e61365309L414-L417) ("// Get selected posts.") will make sure only the selected records index-from and -to will be imported.

But there is also the `if ( 2000 === $post_index ) { break; }` which is removed by this PR. These lines will disable importing all records at once (if index-from and -to are not used) and will exit after 2000. We don't need this block, removed by this PR.


## How to test
- no need to test this one, just removing extra code

---

- [x] confirmed that PHPCS has been run
