### PR TITLE
Embarcadero Migrator, import comments wo/ user, and smaller updates

### DIFF
--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -40,6 +40,7 @@ use \WP_CLI;
  *     - wp newspack-content-migrator embarcadero-migrate-comments \
  *       --comments-csv-file-path=/path/to/comments.csv \
  *       --comments-zones-file-path=/path/to/comment_zones.csv
+ *       --users-file-path==/path/to/registrated_users.csv
  *
  *     - wp newspack-content-migrator embarcadero-migrate-print-issues \
  *       --publication-name="Danville San Ramon" \
@@ -48,6 +49,11 @@ use \WP_CLI;
  *       --print-sections-csv-file-path=/path/to/print_sections.csv \
  *       --print-pdf-dir-path=/path/to/morguepdf \
  *       --print-cover-dir-path=/path/to/covers
+ *
+ * *** One method to fix CSVs which can't be read (because of quotes in wrong places):
+ *  1. convert your CSV to TSV using OSX's Pages
+ *  2. feed the TSV to the helper command embarcadero-helper-fix-tsv-file and get a new fixed TSV file
+ *  3. feed the new fixed TSV file instead of the --csv-file= argument in the import command -- it will also accept TSVs, even though the argument name says CSV
  *
  * @package NewspackCustomContentMigrator
  */
@@ -66,11 +72,15 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 	const DEFAULT_AUTHOR_NAME                       = 'Staff';
 
 	/**
+	 * Instance.
+	 *
 	 * @var null|InterfaceCommand Instance.
 	 */
 	private static $instance = null;
 
 	/**
+	 * Logger instance.
+	 *
 	 * @var Logger.
 	 */
 	private $logger;
@@ -83,11 +93,15 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 	private $attachments;
 
 	/**
+	 * CoAuthorsPlus instance.
+	 *
 	 * @var CoAuthorPlus $coauthorsplus_logic
 	 */
 	private $coauthorsplus_logic;
 
 	/**
+	 * GutenbergBlockGenerator instance.
+	 *
 	 * @var GutenbergBlockGenerator.
 	 */
 	private $gutenberg_block_generator;
@@ -378,6 +392,30 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 				],
 			]
 		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator embarcadero-helper-fix-tsv-file',
+			array( $this, 'cmd_embarcadero_helper_fix_tsv_file' ),
+			[
+				'shortdesc' => 'A helper command which takes a TSV file and tries to fix the ambiguous \"" and \" escaping.',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'tsv-file-input',
+						'description' => 'Full path to TSV file which is having issues being read by filecsv( $file, null, "\t" ).',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'tsv-file-output',
+						'description' => 'Where to save the new (hopefully fixed) content. Full file path.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -403,12 +441,12 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			WP_CLI::error( 'Co-Authors Plus plugin not found. Install and activate it before using this command.' );
 		}
 
-		$posts                 = $this->get_data_from_csv( $story_csv_file_path );
-		$contributors          = $this->get_data_from_csv( $story_byline_emails_csv_file_path );
-		$sections              = $this->get_data_from_csv( $story_sections_csv_file_path );
-		$photos                = $this->get_data_from_csv( $story_photos_csv_file_path );
-		$media                 = $this->get_data_from_csv( $story_media_csv_file_path );
-		$carousel_items        = $this->get_data_from_csv( $story_carousel_items_dir_path );
+		$posts                 = $this->get_data_from_csv_or_tsv( $story_csv_file_path );
+		$contributors          = $this->get_data_from_csv_or_tsv( $story_byline_emails_csv_file_path );
+		$sections              = $this->get_data_from_csv_or_tsv( $story_sections_csv_file_path );
+		$photos                = $this->get_data_from_csv_or_tsv( $story_photos_csv_file_path );
+		$media                 = $this->get_data_from_csv_or_tsv( $story_media_csv_file_path );
+		$carousel_items        = $this->get_data_from_csv_or_tsv( $story_carousel_items_dir_path );
 		$imported_original_ids = $this->get_posts_meta_values_by_key( self::EMBARCADERO_ORIGINAL_ID_META_KEY );
 
 		// Get selected posts.
@@ -509,6 +547,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			}
 
 			// Migrate post content shortcodes.
+			// phpcs:ignore
 			$post_content         = str_replace( "\n", "</p>\n<p>", '<p>' . $post['story_text'] . '</p>' );
 			$updated_post_content = $this->migrate_post_content_shortcodes( $post['story_id'], $wp_post_id, $post_content, $photos, $story_photos_dir_path, $media, $carousel_items );
 
@@ -606,7 +645,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 	public function cmd_embarcadero_migrate_post_tags( $args, $assoc_args ) {
 		$story_tags_csv_file_path = $assoc_args['story-tags-csv-file-path'];
 
-		$tags                  = $this->get_data_from_csv( $story_tags_csv_file_path );
+		$tags                  = $this->get_data_from_csv_or_tsv( $story_tags_csv_file_path );
 		$imported_original_ids = $this->get_posts_meta_values_by_key( self::EMBARCADERO_IMPORTED_TAG_META_KEY );
 
 		$grouped_tags = [];
@@ -653,7 +692,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$story_photos_csv_file_path = $assoc_args['story-photos-file-path'];
 		$story_photos_dir_path      = $assoc_args['story-photos-dir-path'];
 
-		$photos                = $this->get_data_from_csv( $story_photos_csv_file_path );
+		$photos                = $this->get_data_from_csv_or_tsv( $story_photos_csv_file_path );
 		$imported_original_ids = $this->get_posts_meta_values_by_key( self::EMBARCADERO_IMPORTED_FEATURED_META_KEY );
 
 		$featured_photos = array_values(
@@ -719,8 +758,8 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$story_csv_file_path       = $assoc_args['story-csv-file-path'];
 		$story_media_csv_file_path = $assoc_args['story-media-file-path'];
 
-		$posts                 = $this->get_data_from_csv( $story_csv_file_path );
-		$media_list            = $this->get_data_from_csv( $story_media_csv_file_path );
+		$posts                 = $this->get_data_from_csv_or_tsv( $story_csv_file_path );
+		$media_list            = $this->get_data_from_csv_or_tsv( $story_media_csv_file_path );
 		$imported_original_ids = $this->get_posts_meta_values_by_key( self::EMBARCADERO_IMPORTED_MORE_POSTS_META_KEY );
 
 		// Skip already imported posts.
@@ -753,7 +792,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 				array_filter(
 					$media_list,
 					function( $media_item ) use ( $post ) {
-						return $media_item['story_id'] === $post['story_id'] && $media_item['media_type'] === 'more_stories';
+						return $media_item['story_id'] === $post['story_id'] && 'more_stories' === $media_item['media_type'];
 					}
 				)
 			);
@@ -798,8 +837,8 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$story_photos_csv_file_path = $assoc_args['story-photos-file-path'];
 		$story_photos_dir_path      = $assoc_args['story-photos-dir-path'];
 
-		$posts  = $this->get_data_from_csv( $story_csv_file_path );
-		$photos = $this->get_data_from_csv( $story_photos_csv_file_path );
+		$posts  = $this->get_data_from_csv_or_tsv( $story_csv_file_path );
+		$photos = $this->get_data_from_csv_or_tsv( $story_photos_csv_file_path );
 
 		foreach ( $posts as $post_index => $post ) {
 			$this->logger->log( self::LOG_FILE, sprintf( 'Migrating images for the post %d/%d: %d', $post_index + 1, count( $posts ), $post['story_id'] ), Logger::LINE );
@@ -844,9 +883,9 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$users_file_path              = $assoc_args['users-file-path'];
 		$imported_original_ids        = $this->get_comments_meta_values_by_key( self::EMBARCADERO_IMPORTED_COMMENT_META_KEY );
 
-		$comments = $this->get_data_from_csv( $comments_csv_file_path );
-		$zones    = $this->get_data_from_csv( $comments_zones_csv_file_path );
-		$users    = $this->get_data_from_csv( $users_file_path );
+		$comments = $this->get_data_from_csv_or_tsv( $comments_csv_file_path );
+		$zones    = $this->get_data_from_csv_or_tsv( $comments_zones_csv_file_path );
+		$users    = $this->get_data_from_csv_or_tsv( $users_file_path );
 
 		// Skip already imported comments.
 		$comments = array_values(
@@ -934,8 +973,8 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$print_cover_dir_path         = $assoc_args['print-cover-dir-path'];
 		$imported_original_ids        = $this->get_comments_meta_values_by_key( self::EMBARCADERO_IMPORTED_PRINT_ISSUE_META_KEY );
 
-		$print_issues   = $this->get_data_from_csv( $print_issues_csv_file_path );
-		$print_sections = $this->get_data_from_csv( $print_sections_csv_file_path );
+		$print_issues   = $this->get_data_from_csv_or_tsv( $print_issues_csv_file_path );
+		$print_sections = $this->get_data_from_csv_or_tsv( $print_sections_csv_file_path );
 
 		// Skip already imported print issues.
 		$print_issues = array_values(
@@ -1051,13 +1090,114 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 	}
 
 	/**
+	 * Callable for `newspack-content-migrator embarcadero-helper-fix-tsv-file`.
+	 *
+	 * Takes a TSV file and tries to fix the ambiguous \"" and \" escaping and produces a new, fixed TSV file.
+	 *
+	 * @param array $pos_args   Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 *
+	 * @return void
+	 */
+	public function cmd_embarcadero_helper_fix_tsv_file( $pos_args, $assoc_args ) {
+		$file_input  = $assoc_args['tsv-file-input'];
+		$file_output = $assoc_args['tsv-file-output'];
+
+		if ( ! file_exists( $file_input ) ) {
+			WP_CLI::error( 'File does not exist: ' . $file_input );
+		}
+		$tsv_file = fopen( $file_input, 'r' );
+		if ( false === $tsv_file ) {
+			WP_CLI::error( 'Could not open file: ' . $file_input );
+		}
+		$tsv_headers = fgetcsv( $tsv_file, null, "\t" );
+		if ( false === $tsv_headers ) {
+			WP_CLI::error( 'Could not read TSV headers from file: ' . $file_input );
+		}
+
+		// We'll work on a temp file until fixed, then we mv it to the output file.
+		$file_tmp = $file_output . '.tmp';
+		copy( $file_input, $file_tmp );
+
+		$fixes_made = false;
+		$faulty_row = null;
+		do {
+			$fixed = true;
+
+			$tsv_file    = fopen( $file_tmp, 'r' );
+			$tsv_array   = fgetcsv( $tsv_file, null, "\t" );
+			$tsv_headers = array_map( 'trim', $tsv_array );
+
+
+			// Read TSV until a faulty row is found, and then set $fixed to false and stop.
+			while (
+				( ( $tsv_row = fgetcsv( $tsv_file, null, "\t" ) ) !== false )
+				&& ( false !== $fixed )
+			) {
+				if ( count( $tsv_row ) !== count( $tsv_headers ) ) {
+					$faulty_row = current( $tsv_row );
+					WP_CLI::warning( 'Can not read TSV row ID ' . $faulty_row );
+					$fixed = false;
+					continue;
+				}
+			}
+
+			/**
+			 * It failed for the first time (), then try and replace the faulty row with a fixed one.
+			 */
+			if ( false === $fixed ) {
+
+				$next_row = $faulty_row + 1;
+
+				$from = "\n{$faulty_row}\t";
+				$to   = "\n{$next_row}\t";
+
+				// Get faulty row.
+				$full_file_contents = file_get_contents( $file_tmp );
+				$pos_from           = strpos( $full_file_contents, $from );
+				$pos_to             = strpos( $full_file_contents, $to );
+				if ( ! $pos_from ) {
+					// This shouldn't be, but check just in case.
+					WP_CLI::error( sprintf( 'Was not able to match \'%s\' string position in TSV file.', $from ) );
+				}
+				// And if $to is not found, do replacements in file until the end of content ($pos_to=null will be used as $length argument for substr down below).
+				if ( false === $pos_to ) {
+					$pos_to = null;
+				}
+
+				WP_CLI::line( sprintf( 'Fixing quotes from %d to %s ...', $faulty_row, $next_row ?? 'end' ) );
+				$offending_record          = substr( $full_file_contents, $pos_from, $pos_to - $pos_from + 1 );
+				$offending_record_replaced = str_replace( '\""', '\"', $offending_record );
+				$full_file_contents        = str_replace( $offending_record, $offending_record_replaced, $full_file_contents );
+				file_put_contents( $file_tmp, $full_file_contents );
+
+				$fixes_made = true;
+			}
+		} while ( true !== $fixed );
+
+		fclose( $tsv_file );
+
+		// Move file from $file_tmp to $file_output.
+		if ( true === $fixes_made ) {
+			rename( $file_tmp, $file_output );
+			WP_CLI::success( 'Fixed file saved to: ' . $file_output );
+		}
+	}
+
+	/**
 	 * Get data from CSV file.
 	 *
 	 * @param string $story_csv_file_path Path to the CSV file containing the stories to import.
 	 * @return array Array of data.
 	 */
-	private function get_data_from_csv( $story_csv_file_path ) {
+	private function get_data_from_csv_or_tsv( $story_csv_file_path ) {
 		$data = [];
+
+		// Reading CSV or TSV.
+		$separator = ',';
+		if ( '.tsv' == strtolower( substr( $story_csv_file_path, -4 ) ) ) {
+			$separator = "\t";
+		}
 
 		if ( ! file_exists( $story_csv_file_path ) ) {
 			$this->logger->log( self::LOG_FILE, 'File does not exist: ' . $story_csv_file_path, Logger::ERROR );
@@ -1068,14 +1208,14 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			$this->logger->log( self::LOG_FILE, 'Could not open file: ' . $story_csv_file_path, Logger::ERROR );
 		}
 
-		$csv_headers = fgetcsv( $csv_file );
-		if ( false === $csv_headers ) {
+		$csv_row = fgetcsv( $csv_file, null, $separator );
+		if ( false === $csv_row ) {
 			$this->logger->log( self::LOG_FILE, 'Could not read CSV headers from file: ' . $story_csv_file_path, Logger::ERROR );
 		}
 
-		$csv_headers = array_map( 'trim', $csv_headers );
+		$csv_headers = array_map( 'trim', $csv_row );
 
-		while ( ( $csv_row = fgetcsv( $csv_file ) ) !== false ) {
+		while ( ( $csv_row = fgetcsv( $csv_file, null, $separator ) ) !== false ) {
 			if ( count( $csv_row ) !== count( $csv_headers ) ) {
 				$this->logger->log( self::LOG_FILE, 'Could not read CSV row (' . current( $csv_row ) . ') from file: ' . $story_csv_file_path, Logger::WARNING );
 				continue;

--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -50,7 +50,7 @@ use \WP_CLI;
  *       --print-pdf-dir-path=/path/to/morguepdf \
  *       --print-cover-dir-path=/path/to/covers
  *
- * *** One method to fix CSVs which can't be read (because of quotes in wrong places):
+ * *** How to fix CSVs if migrator reports that some rows can't be read (different count of header columns and found data columns for a row):
  *  1. convert your CSV to TSV using OSX's Pages
  *  2. feed the TSV to the helper command embarcadero-helper-fix-tsv-file and get a new fixed TSV file
  *  3. feed the new fixed TSV file instead of the --csv-file= argument in the import command -- it will also accept TSVs, even though the argument name says CSV


### PR DESCRIPTION
- Command `embarcadero-migrate-comments` now imports comments even if coment's user is not found (WP accepts comments without a WP_User attached to them)

I also added a helper command with a workflow which helped me fix a broken CSV for Pleasanton. It's a bit elaborate/specific, but it does the trick. I tried several variations, and this one worked:
- Added the helper command `embarcadero-helper-fix-tsv-file` which helps fix broken CSVs. I've shared how it's used up in the comments at the top of the class -- see "How to fix CSVs if migrator reports that some rows can't be read":
    1. convert CSV to TSV using OSX Pages. I first converted CSV to TSV this because commas are a part of the problem, and tab-separated-values bypass all that. Also everyone from our Team has Pages and it works well (even with 300MB CSVs)
    2. feed the the resulting TSV through my helper command as argument -- iterates through all records, and fixes the  incompatible `\""` or `\"` escapings of the the double quote
    3. then use the resulting fixed TSV instead of CSV for the importer command (in my case it was the import comments and the broken comments.csv)
- Updated existing function `get_data_from_csv` to `get_data_from_csv_or_tsv` so that it now works with both CSVs and TSVs

## How to test
- this is an edge case -- in case of a broken CSV, follow instructions under "One method to fix CSVs which can't be read" to get a fixed TSV and use it instead of the original CSV
- if a record in comments.csv references an user which is not in the users CSV, it will still get imported with blank user data

---

- [x] confirmed that PHPCS has been run
