### PR TITLE
Add command to update nicenames

### DIFF
--- a/src/Command/General/UsersMigrator.php
+++ b/src/Command/General/UsersMigrator.php
@@ -155,6 +155,8 @@ class UsersMigrator implements InterfaceCommand {
 	 * @return void
 	 */
 	public function users_fix_unsafe_nicenames( array $args, array $assoc_args ): void {
+		WP_CLI::confirm( "PLEASE NOTE!! \nThis does _NOT_ fix the problems with slugs we have with co-authors-plus. \nIn fact - it might make things worse. Use this function only if you are cleaning up users – not co-authors. 
+			Do you want to continue?" );
 		$log_file        = __FUNCTION__ . '.log';
 		$users_per_batch = isset( $assoc_args['users-per-batch'] ) ? intval( $assoc_args['users-per-batch'] ) : 10000;
 		$batch           = isset( $assoc_args['batch'] ) ? intval( $assoc_args['batch'] ) : 1;


### PR DESCRIPTION
This updates user nicenames to a slugified version of their display name (or a random string if display name is not available).

## How to test
- Run it on users and see that the nicename (slug) changes to their display name or some random string.

---

- [x] confirmed that PHPCS has been run
