### PR TITLE
Taxonomy Migrator: Sanitize text added to category descriptions

### DIFF
--- a/src/Command/General/TaxonomyMigrator.php
+++ b/src/Command/General/TaxonomyMigrator.php
@@ -781,7 +781,7 @@ class TaxonomyMigrator implements InterfaceCommand {
 			$catarr = array(
 				'cat_name'             => $term->name,
 				'category_nicename'    => $term->slug,
-				'category_description' => $term->description,
+				'category_description' => wp_strip_all_tags( strip_shortcodes( $term->description ) ),
 			);
 			if ( $parent_category ) {
 				$catarr['category_parent'] = $parent_category->term_id;


### PR DESCRIPTION
# Tiny fix

I had some shortcodes and other stuff get migrated into category descriptions using `convert_term_to_category()`. This just escapes it.

## How to test
Probably enough to just eyeball the code :) 


