### PR TITLE
fix(EmbarcaderoMigrator): use the correct topic ID when importing comments

### DIFF
--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -64,6 +64,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 	const FEATURED_IMAGES_LOG_FILE                  = 'embarcadero_featured_images_migrator.log';
 	const MORE_POSTS_LOG_FILE                       = 'embarcadero_more_posts_migrator.log';
 	const EMBARCADERO_ORIGINAL_ID_META_KEY          = '_newspack_import_id';
+	const EMBARCADERO_ORIGINAL_TOPIC_ID_META_KEY    = '_newspack_import_topic_id';
 	const EMBARCADERO_IMPORTED_TAG_META_KEY         = '_newspack_import_tag_id';
 	const EMBARCADERO_IMPORTED_FEATURED_META_KEY    = '_newspack_import_featured_image_id';
 	const EMBARCADERO_IMPORTED_MORE_POSTS_META_KEY  = '_newspack_import_more_posts_image_id';
@@ -618,6 +619,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 
 			// Set the original ID.
 			update_post_meta( $wp_post_id, self::EMBARCADERO_ORIGINAL_ID_META_KEY, $post['story_id'] );
+			update_post_meta( $wp_post_id, self::EMBARCADERO_ORIGINAL_TOPIC_ID_META_KEY, $post['topic_id'] );
 
 			// Set the post subhead.
 			update_post_meta( $wp_post_id, 'newspack_post_subtitle', $post['subhead'] );
@@ -1039,7 +1041,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 
 			$this->logger->log( self::LOG_FILE, sprintf( 'Migrating comment for the post %d/%d: %d', $comment_index + 1, count( $comments ), $comment['topic_id'] ), Logger::LINE );
 
-			$wp_post_id = $this->get_post_id_by_meta( self::EMBARCADERO_ORIGINAL_ID_META_KEY, $comment['topic_id'] );
+			$wp_post_id = $this->get_post_id_by_meta( self::EMBARCADERO_ORIGINAL_TOPIC_ID_META_KEY, $comment['topic_id'] );
 
 			if ( ! $wp_post_id ) {
 				$this->logger->log( self::TAGS_LOG_FILE, sprintf( 'Could not find post with the original ID %d', $comment['topic_id'] ), Logger::WARNING );
@@ -1082,7 +1084,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 				'comment_post_ID'      => $wp_post_id,
 				'comment_approved'     => 'no' === $comment['hide'],
 				'user_id'              => $wp_user ? $wp_user->ID : '',
-				'comment_author'       => $wp_user ? $wp_user->user_login : '',
+				'comment_author'       => $wp_user ? $wp_user->user_nicename : $comment['user_name'],
 				'comment_author_email' => $wp_user ? $wp_user->user_email : '',
 				'comment_author_url'   => $wp_user ? $wp_user->user_url : '',
 				'comment_author_IP'    => $comment['ip_address'] ?? '',


### PR DESCRIPTION
Import stories missing `topic_id`, and use it to correctly import comments.

## How to test
- Re-run the `embarcadero-import-posts-content` with the flags `--refresh-content --skip-post-content`
- Clean all imported comments from the database (purge wp_comments and wp_commentmeta tables).
- Re-run `embarcadero-migrate-comments` command.
- Check a few posts and make sure the comments are imported to the correct posts.

---

- [x] confirmed that PHPCS has been run
