### PR TITLE
Helper to make batching easier

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -67,6 +67,7 @@ PluginSetup::register_migrators(
 		Command\General\ChorusCmsMigrator::class,
 		Command\General\LedeMigrator::class,
 		Command\General\DownloadMissingImages::class,
+		Command\General\MigrationHelper::class,
 
 		// Publisher specific, remove when launched.
 		Command\PublisherSpecific\GadisMigrator::class,

--- a/src/Command/General/MigrationHelper.php
+++ b/src/Command/General/MigrationHelper.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Command\General;
+
+use Exception;
+use NewspackCustomContentMigrator\Command\InterfaceCommand;
+use NewspackCustomContentMigrator\Utils\BatchLogic;
+use WP_CLI;
+use WP_CLI\ExitException;
+
+class MigrationHelper implements InterfaceCommand {
+	private function __construct() {
+		// Do nothing.
+	}
+
+	/**
+	 * Get Instance.
+	 *
+	 * @return self
+	 */
+	public static function get_instance(): self {
+		static $instance = null;
+		if ( null === $instance ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function register_commands(): void {
+		WP_CLI::add_command( 'newspack-content-migrator migration-helper-output-batched',
+			[ $this, 'cmd_output_batched' ], [
+				'shortdesc' => 'Outputs commands batched. Only outputs the command strings – will not run any of the commands.',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'batch-size',
+						'description' => 'Number of items to be processed in each batch.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'total-items',
+						'description' => 'How many items to process in total.', // TODO. Better description.
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'begin-at',
+						'description' => 'Number we should start from',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'positional',
+						'name'        => 'command-string',
+						'description' => 'Command you want to run. Use "" quotes around the command and feel free to add as many args INSIDE those as you want.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'start-arg-name',
+						'description' => 'Name of start arg. Optional. Defaults to values in the BatchLogic class',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'end-arg-name',
+						'description' => 'Name of end arg. Optional. Defaults to values in the BatchLogic class',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * @throws ExitException
+	 */
+	public function cmd_output_batched( array $positional_args, array $assoc_args ): void {
+		$begin_at       = $assoc_args['begin-at'] ?? 0;
+		$total_items    = $assoc_args['total-items'];
+		$batch_size     = $assoc_args['batch-size'];
+		$command_string = $positional_args[0] ?? false;
+		$start_arg_name = $assoc_args['start-arg-name'] ?? BatchLogic::$start['name'];
+		$end_arg_name   = $assoc_args['end-arg-name'] ?? BatchLogic::$end['name'];
+
+		if ( $command_string ) {
+			if ( empty( preg_match( '/(wp\s\S+\s\S+)/', $command_string, $matches ) ) ) {
+				WP_CLI::error( 'Command does not look valid. It should start with 3 words like "wp command-this command-that"' );
+			}
+			$command        = $matches[1];
+			$command_args   = trim( str_replace( $command, '', $command_string ) );
+			$command_args   = trim( preg_replace( '/\s+/', " \\\n", $command_args ), '\\' );
+			$command_string = $command . " \\\n" . $command_args . " \\";
+		}
+
+		if ( $begin_at > 0 ) {
+			$total_items = $total_items - $begin_at;
+		}
+		$num_batches = ceil( $total_items / $batch_size );
+
+		for ( $batch = 0; $batch < $num_batches; $batch ++ ) {
+			$batch_start = ( $batch * $batch_size ) + $begin_at;
+			$batch_end   = $batch_start + $batch_size;
+			if ( $batch_end > $total_items ) {
+				$batch_end = 0;
+			}
+			WP_CLI::line( sprintf( '# MigrationHelper: Batch %d of %d', $batch + 1, $num_batches ) );
+			if ( $command_string ) {
+				WP_CLI::line( $command_string );
+			}
+			WP_CLI::line( self::get_batch_string( $start_arg_name, $end_arg_name, $batch_start, $batch_end ) . PHP_EOL );
+		}
+	}
+
+	public static function get_batch_string( string $start_arg_name, string $end_arg_name, int $start, int $end ): string {
+		$batch_string = '';
+
+		if ( $start > 0 ) {
+			$batch_string .= sprintf( ' --%s=%d', $start_arg_name, $start );
+		}
+
+		if ( $end > 0 ) {
+			$batch_string .= sprintf( ' --%s=%d', $end_arg_name, $end );
+		}
+
+		return $batch_string;
+
+	}
+
+}

--- a/src/Command/General/MigrationHelper.php
+++ b/src/Command/General/MigrationHelper.php
@@ -77,6 +77,13 @@ class MigrationHelper implements InterfaceCommand {
 						'optional'    => true,
 						'repeating'   => false,
 					],
+					[
+						'type'        => 'flag',
+						'name'        => 'iterm-trigger',
+						'description' => 'Print a trigger for iTerm to pick up after the command has run.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
 				],
 			]
 		);
@@ -92,6 +99,7 @@ class MigrationHelper implements InterfaceCommand {
 		$command_string = $positional_args[0] ?? false;
 		$start_arg_name = $assoc_args['start-arg-name'] ?? BatchLogic::$start['name'];
 		$end_arg_name   = $assoc_args['end-arg-name'] ?? BatchLogic::$end['name'];
+		$iterm_trigger  = $assoc_args['iterm-trigger'] ?? false;
 
 		if ( $command_string ) {
 			if ( empty( preg_match( '/(wp\s\S+\s\S+)/', $command_string, $matches ) ) ) {
@@ -114,11 +122,20 @@ class MigrationHelper implements InterfaceCommand {
 			if ( $batch_end > $total_items ) {
 				$batch_end = 0;
 			}
-			WP_CLI::line( sprintf( '# MigrationHelper: Batch %d of %d', $batch + 1, $num_batches ) );
+			$batch_info = sprintf( 'Batch %d of %d', $batch + 1, $num_batches );
+			WP_CLI::line( sprintf( '# MigrationHelper: %s', $batch_info ) );
 			if ( $command_string ) {
-				WP_CLI::line( $command_string );
+				WP_CLI::out( $command_string );
 			}
-			WP_CLI::line( self::get_batch_string( $start_arg_name, $end_arg_name, $batch_start, $batch_end ) . PHP_EOL );
+
+			WP_CLI::out( self::get_batch_string( $start_arg_name, $end_arg_name, $batch_start, $batch_end )  );
+
+			if ( $iterm_trigger ) {
+				WP_CLI::line( sprintf( ' && echo "MigrationHelper says:___(%s)___"', $batch_info ) );
+			} else {
+				WP_CLI::line( '' ); // Just to add a newline for ease of copypasta
+			}
+
 		}
 	}
 


### PR DESCRIPTION
Inspired by frustration with internet connection cutting out and trying to navigate running scripts with `start` and `end`. It's super hard to keep track of what ran and what didn't in that case.

This thingy doesn't run anything, but outputs a bunch of commands that can be pasted in a file and then run one by one or in multiple terminals. 

## How to test
- With some command that supports `from` and `to` run like this:
```bash
wp newspack-content-migrator migration-helper-output-batched \
"wp newspack-content-migrator some-command --some-arg=horse --other-arg=goat" \
--total-items=122 --batch-size=60
```
- You need to know how many items you are running (or choose a random number high enough). 

- If your command doesn't use the `BatchLogic` class, you can pass the name of the `from` and `to` like this: `--start-arg-name=index-from --end-arg-name=index-to`

- If you need to start a ways in you can pass `--begin-at=<some-number>`.

You will get an output like this that you can copy paste from:
```bash
# MigrationHelper: Batch 1 of 3
wp newspack-content-migrator some-command \
--some-arg=horse \
--other-arg=goat \
 --end=60

# MigrationHelper: Batch 2 of 3
wp newspack-content-migrator some-command \
--some-arg=horse \
--other-arg=goat \
 --start=60 --end=120

# MigrationHelper: Batch 3 of 3
wp newspack-content-migrator some-command \
--some-arg=horse \
--other-arg=goat \
 --start=120
```
## Todo
- [x] Better documentation
- [x] Better processing of the passed command. It works, but might botch stuff with whitespace in unexpected places

---

- [x] confirmed that PHPCS has been run
