### PR TITLE
Add a CSV file iterator that uses the BatchLogic

### DIFF
--- a/src/Utils/CsvIterator.php
+++ b/src/Utils/CsvIterator.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Wrapper class for csv file iteration using BatchLogic.
+ *
+ * @package NewspackCustomContentMigrator
+ */
+
+namespace NewspackCustomContentMigrator\Utils;
+
+use Exception;
+use WP_CLI;
+
+class CsvIterator {
+
+	/**
+	 * @param string $csv_path Path to CSV file.
+	 * @param string $separator Separator for CSV file.
+	 *
+	 * @return iterable
+	 * @throws Exception
+	 */
+	private function items( string $csv_path, string $separator ): iterable {
+		if ( ! is_readable( $csv_path ) ) {
+			WP_CLI::error( "Could not read CSV file: $csv_path" );
+
+			return [];
+		}
+
+		$csv_file    = fopen( $csv_path, 'r' );
+		$csv_headers = [];
+		$line_number = 0;
+		while ( false !== ( $line = fgetcsv( $csv_file, null, $separator ) ) ) {
+			++ $line_number;
+			if ( $line_number === 1 ) {
+				$csv_headers = array_map( 'trim', $line );
+				continue;
+			}
+			yield array_combine( $csv_headers, array_map( 'trim', $line ) );
+		}
+		fclose( $csv_file );
+	}
+
+	/**
+	 * @param string $csv_file Path to CSV file.
+	 * @param string $separator Separator for CSV file.
+	 * @param int    $start Start number (inclusive) line in the file.
+	 * @param int    $end End number (exclusive) line in the file.
+	 *
+	 * @return iterable
+	 * @throws Exception
+	 */
+	public function batched_items( string $csv_file, string $separator, int $start, int $end ): iterable {
+		$item_no = 0;
+		foreach ( $this->items( $csv_file, $separator ) as $item ) {
+			$item_no ++;
+			if ( 0 !== $start && $item_no < $start ) {
+				// Keep looping until we get to where we want to be in the file.
+				continue;
+			}
+
+			if ( $item_no < $end ) {
+				yield $item;
+			} else {
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Will count number of entries in a CSV file.
+	 *
+	 * Handy for getting a "total" number for progress bars and such.
+	 *
+	 * @param string $csv_file_path Path to the CSV file.
+	 *
+	 * @return int Number of entries in the array in the CSV file.
+	 *
+	 * @throws Exception
+	 */
+	public function count_csv_file_entries( string $csv_file_path, string $separator ): int {
+		return count( [ ... $this->items( $csv_file_path, $separator ) ] );
+	}
+
+	/**
+	 * Will validate and get batch args for a CSV file.
+	 *
+	 * @param string $csv_path Path to CSV file.
+	 * @param array  $assoc_args Args from WP CLI command.
+	 * @param string $separator Separator for CSV file.
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function validate_and_get_batch_args_for_file( string $csv_path, array $assoc_args, string $separator ): array {
+		$batch_args = BatchLogic::validate_and_get_batch_args( $assoc_args );
+
+		if ( PHP_INT_MAX === $batch_args['end'] ) {
+			$batch_args['total'] = $this->count_csv_file_entries( $csv_path, $separator );
+			if ( 1 !== $batch_args['start'] ) {
+				$batch_args['total'] = $batch_args['total'] - $batch_args['start'];
+			}
+		}
+
+		return $batch_args;
+	}
+}

--- a/src/Utils/CsvIterator.php
+++ b/src/Utils/CsvIterator.php
@@ -19,7 +19,7 @@ class CsvIterator {
 	 * @return iterable
 	 * @throws Exception
 	 */
-	private function items( string $csv_path, string $separator ): iterable {
+	public function items( string $csv_path, string $separator ): iterable {
 		if ( ! is_readable( $csv_path ) ) {
 			WP_CLI::error( "Could not read CSV file: $csv_path" );
 


### PR DESCRIPTION
This adds a CSV iterator a lot like the JsonIterator we already have. It uses BatchLogic args so it should be easy to use without having to do math.

## How to test
Test that all lines are read correctly passing in nothing, `--start=x` and/or `--end=x`.
Use a .csv file something like this:
```php
		$csv_file_path = $assoc_args[ $this->csv_input_file['name'] ];
		$batch_args = $this->csv_iterator->validate_and_get_batch_args_for_file( $csv_file_path, $assoc_args, ',' );
		$counter    = 0;
		foreach ( $this->csv_iterator->batched_items( $csv_file_path, ',', $batch_args['start'], $batch_args['end'] ) as $row ) {
}
``` 
To use the BatchLogic, register a command something like this:
```php
	private array $csv_input_file = [
		'type'        => 'assoc',
		'name'        => 'csv-input-file',
		'description' => 'Path to CSV input file.',
		'optional'    => false,
	];

	public function register_commands(): void {
		WP_CLI::add_command(
			'newspack-content-migrator my-test-thing',
			[ $this, 'cmd_test-thing' ],
			[
				'shortdesc' => 'Test the thing!.',
				'synopsis'  => [
					$this->csv_input_file,
					...BatchLogic::get_batch_args(),
				],
			]
		);
	}
```

---

- [x] confirmed that PHPCS has been run
