### PR TITLE
Add/console output table

### DIFF
--- a/src/Utils/ConsoleTable.php
+++ b/src/Utils/ConsoleTable.php
@@ -8,6 +8,7 @@
 namespace NewspackCustomContentMigrator\Utils;
 
 use cli\Table;
+use WP_CLI;
 
 /**
  * Class to output various tables to the console.
@@ -156,5 +157,28 @@ class ConsoleTable {
 			'different'    => $different_rows,
 			'undetermined' => $undetermined_rows,
 		);
+	}
+
+	/**
+	 * Simple function to output a table of data, with an optional title.
+	 *
+	 * @param array  $array_of_arrays An array of arrays that hold the data to be output.
+	 * @param array  $header An array of strings that will be used as the table header.
+	 * @param string $title The title of the table.
+	 *
+	 * @return void
+	 */
+	public function output_data( array $array_of_arrays, array $header = [], string $title = '' ) {
+		if ( empty( $header ) && isset( $array_of_arrays[0] ) ) {
+			$header = array_keys( $array_of_arrays[0] );
+		}
+
+		if ( ! empty( $title ) ) {
+			$title         = WP_CLI::colorize( '%B%U' . $title . '%n' ) . PHP_EOL;
+			$title_escaped = esc_html( $title );
+			echo $title_escaped; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+
+		WP_CLI\Utils\format_items( 'table', $array_of_arrays, $header );
 	}
 }

--- a/src/Utils/ConsoleTable.php
+++ b/src/Utils/ConsoleTable.php
@@ -51,7 +51,17 @@ class ConsoleTable {
 			);
 
 			foreach ( $array_bag as $array ) {
-				$row[] = $array[ $key ] ?? '';
+				if ( array_key_exists( $key, $array ) ) {
+					if ( is_bool( $array[ $key ] ) ) {
+						$row[] = $array[ $key ] ? 'true' : 'false';
+					} elseif ( empty( $array[ $key ] ) ) {
+						$row[] = '-';
+					} else {
+						$row[] = $array[ $key ] ?? '';
+					}
+				} else {
+					$row[] = '-';
+				}
 			}
 
 			$table->addRow( $row );

--- a/src/Utils/ConsoleTable.php
+++ b/src/Utils/ConsoleTable.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Class to output various tables to the console.
+ *
+ * @package NewspackCustomContentMigrator;
+ */
+
+namespace NewspackCustomContentMigrator\Utils;
+
+use cli\Table;
+
+/**
+ * Class to output various tables to the console.
+ */
+class ConsoleTable {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * This function outputs a comparison table of the given arrays.
+	 *
+	 * @param array $keys Specific keys to compare. If empty, all keys will be compared.
+	 * @param array ...$arrays The arrays to be compared.
+	 *
+	 * @return void
+	 */
+	public function output_comparison( array $keys, array ...$arrays ) {
+		$array_bag = array(
+			...$arrays,
+		);
+
+		if ( empty( $keys ) ) {
+			$keys = array_keys( array_merge( ...$arrays ) );
+		}
+
+		$table = new Table();
+		$table->setHeaders(
+			array(
+				'',
+				...array_keys( $array_bag ),
+			)
+		);
+
+		foreach ( $keys as $key ) {
+			$row = array(
+				$key,
+			);
+
+			foreach ( $array_bag as $array ) {
+				$row[] = $array[ $key ] ?? '';
+			}
+
+			$table->addRow( $row );
+		}
+
+		$table->display();
+	}
+
+	/**
+	 * This function will take two arrays and compare their values key-by-key.
+	 *
+	 * @param array  $keys Specific keys to compare. If empty, all keys will be compared.
+	 * @param array  $left_set First array to compare.
+	 * @param array  $right_set Second array to compare.
+	 * @param bool   $strict Whether to use strict comparison or not.
+	 * @param string $left The name of the first/left array.
+	 * @param string $right The name of the second/right array.
+	 *
+	 * @return array[]
+	 */
+	public function output_value_comparison( array $keys, array $left_set, array $right_set, bool $strict = true, string $left = 'LEFT', string $right = 'RIGHT' ) {
+		if ( empty( $keys ) ) {
+			$keys = array_keys( array_merge( $left_set, $right_set ) );
+		}
+
+		$table = new Table();
+		$table->setHeaders(
+			array(
+				'',
+				'Match?',
+				$left,
+				$right,
+			)
+		);
+
+		$matching_rows     = array();
+		$different_rows    = array();
+		$undetermined_rows = array();
+
+		foreach ( $keys as $key ) {
+			if ( array_key_exists( $key, $left_set ) ) {
+				if ( is_bool( $left_set[ $key ] ) ) {
+					$left_set[ $key ] = $left_set[ $key ] ? 'true' : 'false';
+				}
+			}
+
+			if ( array_key_exists( $key, $right_set ) ) {
+				if ( is_bool( $right_set[ $key ] ) ) {
+					$right_set[ $key ] = $right_set[ $key ] ? 'true' : 'false';
+				}
+			}
+
+			if ( array_key_exists( $key, $left_set ) && array_key_exists( $key, $right_set ) ) {
+				if ( empty( $left_set[ $key ] ) && empty( $right_set[ $key ] ) ) {
+					$match = '-';
+				} else {
+					// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+					$match = $strict ? ( $left_set[ $key ] === $right_set[ $key ] ? '✅' : '❌' ) : ( $left_set[ $key ] == $right_set[ $key ] ? '✅' : '❌' );
+				}
+			} elseif ( empty( $left_set[ $key ] ) && empty( $right_set[ $key ] ) ) {
+				$match = '-';
+			} else {
+				$match = '❌';
+			}
+
+			$values = array(
+				$left  => $left_set[ $key ] ?? '',
+				$right => $right_set[ $key ] ?? '',
+			);
+
+			$row = array(
+				$key,
+				$match,
+				...array_values( $values ),
+			);
+
+			if ( '✅' === $match ) {
+				$matching_rows[ $key ] = $values;
+			} elseif ( '❌' === $match ) {
+				$different_rows[ $key ] = $values;
+			} else {
+				$undetermined_rows[ $key ] = $values;
+			}
+
+			$table->addRow( $row );
+		}
+
+		$table->display();
+
+		return array(
+			'matching'     => $matching_rows,
+			'different'    => $different_rows,
+			'undetermined' => $undetermined_rows,
+		);
+	}
+}


### PR DESCRIPTION
I created this class so that I can easily display arrays while in CLI/Terminal/Console in a table format. Sometimes I need to inspect, and compare values within arrays during migrations or simply when testing a change. I find it extremely helpful to be able to display this data vertically in a table. So the first function (`output_comparison`) in this class does just that:
![image](https://github.com/Automattic/newspack-custom-content-migrator/assets/17132385/6d766e3b-b27b-4983-bb2f-b24bd9f56970)
In the screenshot, it is evident that this function does a few more things automatically to be able to display the data in a table format:
1. Boolean values are converted to strings for display only (i.e. true becomes 'true', false becomes 'false')
2. If an array *does not* have a value for a particular key, a dash ('-') is used to convey this.
3. Arrays, and their keys, are handled dynamically. It doesn't matter if the arrays you need to compare don't have a single matching key.

The next function in this class (`output_value_comparison`) is helpful when you need to compare two array values side-by-side. The display of values is similar to the function above, the difference here is that you have a column which confirms whether the values match or not:
![Comparing `$first_array` against `$second_array`](https://github.com/Automattic/newspack-custom-content-migrator/assets/17132385/b1e8adf0-63d2-4754-a0ea-df6793a81793)
![Comparing `$first_array` against `$third_array`](https://github.com/Automattic/newspack-custom-content-migrator/assets/17132385/75d398ad-fdf7-4917-a31e-3ebae3fc2708)

Another feature of this function is an array which is returned that contains all matching and differing values, as well as any values whose comparison could not be determined.
![image](https://github.com/Automattic/newspack-custom-content-migrator/assets/17132385/d5986afe-e775-498e-8950-30488461382c)

---
- [X] confirmed that PHPCS has been run
