### PR TITLE
Remove unused html purifier library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     "automattic/newspack-content-converter": "dev-master",
     "halaxa/json-machine": "^1.1",
     "mustache/mustache": "^2.14",
-    "simplehtmldom/simplehtmldom": "2.0-RC2",
-    "xemlock/htmlpurifier-html5": "^0.1.11"
+    "simplehtmldom/simplehtmldom": "2.0-RC2"
   },
   "require-dev": {
     "automattic/vipwpcs": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f8351e1a6982dcc18256a8e0215fc65",
+    "content-hash": "0249f64d586f690d324e474063fdf15f",
     "packages": [
         {
             "name": "automattic/newspack-cms-importers",
@@ -355,67 +355,6 @@
                 }
             ],
             "time": "2021-09-13T08:19:44+00:00"
-        },
-        {
-            "name": "ezyang/htmlpurifier",
-            "version": "v4.16.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "523407fb06eb9e5f3d59889b3978d5bfe94299c8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/523407fb06eb9e5f3d59889b3978d5bfe94299c8",
-                "reference": "523407fb06eb9e5f3d59889b3978d5bfe94299c8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0"
-            },
-            "require-dev": {
-                "cerdic/css-tidy": "^1.7 || ^2.0",
-                "simpletest/simpletest": "dev-master"
-            },
-            "suggest": {
-                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
-                "ext-bcmath": "Used for unit conversion and imagecrash protection",
-                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
-                "ext-tidy": "Used for pretty-printing HTML"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "library/HTMLPurifier.composer.php"
-                ],
-                "psr-0": {
-                    "HTMLPurifier": "library/"
-                },
-                "exclude-from-classmap": [
-                    "/library/HTMLPurifier/Language/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-2.1-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Edward Z. Yang",
-                    "email": "admin@htmlpurifier.org",
-                    "homepage": "http://ezyang.com"
-                }
-            ],
-            "description": "Standards compliant HTML filter written in PHP",
-            "homepage": "http://htmlpurifier.org/",
-            "keywords": [
-                "html"
-            ],
-            "support": {
-                "issues": "https://github.com/ezyang/htmlpurifier/issues",
-                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.16.0"
-            },
-            "time": "2022-09-18T07:06:19+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2371,61 +2310,6 @@
                 }
             ],
             "time": "2023-01-01T08:36:10+00:00"
-        },
-        {
-            "name": "xemlock/htmlpurifier-html5",
-            "version": "v0.1.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/xemlock/htmlpurifier-html5.git",
-                "reference": "f0d563f9fd4a82a3d759043483f9a94c0d8c2255"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/xemlock/htmlpurifier-html5/zipball/f0d563f9fd4a82a3d759043483f9a94c0d8c2255",
-                "reference": "f0d563f9fd4a82a3d759043483f9a94c0d8c2255",
-                "shasum": ""
-            },
-            "require": {
-                "ezyang/htmlpurifier": "^4.8",
-                "php": ">=5.2"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^1.1|^2.1",
-                "phpunit/phpunit": ">=4.7 <8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "library/HTMLPurifier/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "xemlock",
-                    "email": "xemlock@gmail.com"
-                }
-            ],
-            "description": "HTML5 element definitions for HTML Purifier",
-            "keywords": [
-                "HTML5",
-                "Purifier",
-                "html",
-                "htmlpurifier",
-                "security",
-                "tidy",
-                "validator",
-                "xss"
-            ],
-            "support": {
-                "issues": "https://github.com/xemlock/htmlpurifier-html5/issues",
-                "source": "https://github.com/xemlock/htmlpurifier-html5/tree/master"
-            },
-            "time": "2019-08-07T17:19:21+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This library was promising, but ended up causing more trouble than helping. This removes it. `simplehtmldom\HtmlDocument` ended up being the way to go.

---

- [x] confirmed that PHPCS has been run
