### PR TITLE
fix(Attachments): fix extension of images without one

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -98,6 +98,12 @@ class Attachments {
 			// Without the extension, the upload will fail because WP will not allow that "file type".
 			$mimetype           = mime_content_type( $tmpfname );
 			$probably_extension = array_search( $mimetype, wp_get_mime_types() );
+
+			// Sometimes the extension is in the format `jpg|jpeg|jpe`. In that case, we need to get the first one.
+			if ( str_contains( $probably_extension, '|' ) ) {
+				$probably_extension = explode( '|', $probably_extension )[0];
+			}
+
 			if ( ! empty( $probably_extension ) ) {
 				$file_array['name'] .= '.' . $probably_extension;
 			}


### PR DESCRIPTION
Using `wp_get_mime_types()` to get the mime type  of an image returns `jpg|jpeg|jpe` as a key to the JPEG mime type instead of one extension, which breaks `media_handle_sideload` since we'll be uploading a file with a `name` ending with `file_name.jpg|jpeg|jpe`. This is a little fix for it.

## How to test
- Use `import_external_file` to upload a JPG image with a filename that doesn't contain the extension.
- Notice the upload is not working.
- Apply the patch and re-run the import.
- Notice that the upload is working.

---

- [x] confirmed that PHPCS has been run
