### PR TITLE
feat: add general ras migrator

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -61,6 +61,7 @@ PluginSetup::register_migrators(
 		Command\General\VillageMediaCMSMigrator::class,
 		Command\General\MetroMigrator::class,
 		Command\General\ProfilePress::class,
+		Command\General\Ras::class,
 		Command\General\TownNewsMigrator::class,
 		Command\General\UsersMigrator::class,
 		Command\General\EmbarcaderoMigrator::class,

--- a/src/Command/General/RasMigrator.php
+++ b/src/Command/General/RasMigrator.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Command\General;
+
+use NewspackCustomContentMigrator\Command\InterfaceCommand;
+use NewspackCustomContentMigrator\Utils\Logger;
+use WP_CLI;
+use Newspack\Reader_Activation;
+use Newspack_Segments_Model;
+use Newspack_Popups_Model;
+
+/**
+ * Profile Press reusable commands.
+ */
+class Ras implements InterfaceCommand
+{
+
+    /**
+     * Instance.
+     *
+     * @var null|InterfaceCommand Instance.
+     */
+    private static $instance = null;
+
+    /**
+     * Sets up Co-Authors Plus plugin dependencies.
+     *
+     * @return InterfaceCommand|null
+     */
+    public static function get_instance()
+    {
+        $class = get_called_class();
+        if (null === self::$instance) {
+            self::$instance = new $class();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * See InterfaceCommand::register_commands.
+     */
+    public function register_commands()
+    {
+        WP_CLI::add_command(
+            'newspack-content-migrator ras-campaign-migrator',
+            [$this, 'cmd_ras_campaign_migrator'],
+            [
+                'shortdesc' => 'Imports Campaigns and checks the last item in the RAS wizard, activating RAS at the end.',
+            ]
+        );
+    }
+
+    /**
+     * Imports Campaigns and checks the last item in the RAS wizard, activating RAS at the end.
+     *
+     * This command is useful if you dont want to manually go through the last step of the RAS wizard, but
+     * instead import the Campaigns from a json file and then activate RAS.
+     *
+     * ## OPTIONS
+     *
+     * <json-url>
+     * : The URL of the json file containing the Campaigns. This must be generated using the newspack-popups export command
+     *
+     * @param array $pos_args   Positional arguments.
+     * @param array $assoc_args Associative arguments.
+     *
+     * @throws \RuntimeException If author term wasn't successfully converted to GA.
+     */
+    public function cmd_ras_campaign_migrator($pos_args, $assoc_args)
+    {
+
+        $is_ready = Reader_Activation::is_ras_ready_to_configure();
+
+        if ( ! $is_ready ) {
+            WP_CLI::error('All prior steps in the RAS wizard must be complete in order to run this command.');
+        }
+
+        // save the json file to a temp file
+        $target_file = tempnam(sys_get_temp_dir(), 'ras-campaigns-');
+        $json_url = $pos_args[0];
+        $json = file_get_contents($json_url);
+        if ( false !== $json ) {
+            WP_CLI::success('Successfully downloaded the json file.');
+        } else {
+            WP_CLI::error('Failed to download the json file.');
+        }
+        file_put_contents($target_file, $json);
+
+        // Deactivate all existing segments.
+        WP_CLI::line('Deactivating all existing segments...');
+		foreach ( Newspack_Segments_Model::get_segments() as $existing_segment ) {
+			$existing_segment['configuration']['is_disabled'] = true;
+			Newspack_Segments_Model::update_segment( $existing_segment );
+		}
+
+		// Deactivate all existing prompts.
+        WP_CLI::line('Deactivating all existing prompts...');
+		$existing_prompts = Newspack_Popups_Model::retrieve_active_popups();
+		foreach ( $existing_prompts as $prompt ) {
+			$updated = \wp_update_post(
+				[
+					'ID'          => $prompt['id'],
+					'post_status' => 'draft',
+				]
+			);
+
+			if ( \is_wp_error( $updated ) ) {
+				return $updated;
+			}
+		}
+
+        // Check if the json is valid.
+        $validation = new \Newspack\Campaigns\Schemas\Package( json_decode( $json ) );
+		if ( ! $validation->is_valid() ) {
+            WP_CLI::error( 'The json file is not valid.' );
+        }
+
+        WP_CLI::runcommand( 'newspack-popups import ' . $target_file );
+
+        Reader_Activation::update_setting( 'enabled', true );
+
+        WP_CLI::success('RAS is now activated.');
+
+    }
+}


### PR DESCRIPTION
This is useful to skip the last step of the RAS wizard, that consists of configuring each Campaign Prompt from the defaults we offer.

With this command you can instead import campaigns from a json file exported from a site used as a model, and then programatically go through that last step on the checklist.

In the future we can expand this migrator to programatically go through other steps in the RAS wizard.

## How to test
- Take a site with many prompts and segments and export its contents `wp newspack-popups export --file=newspack-campaigns.json`
- Put this json file in an publicly accessible URL
- Go to another brand new site and go through the RAS wizard until the last step "Reader Activation Campaign" - Don't complete this last step
- Run this command: `newspack-content-migrator ras-campaign-migrator https://yoursite.com/newspack-campaigns.json`
- Confirm RAS is now enabled and the campaigns prompts have been properly created


---

- [x] confirmed that PHPCS has been run
