### PR TITLE
Feat/migration helper parameters with space

### DIFF
--- a/src/Command/General/MigrationHelper.php
+++ b/src/Command/General/MigrationHelper.php
@@ -8,11 +8,10 @@ use NewspackCustomContentMigrator\Utils\BatchLogic;
 use WP_CLI;
 use WP_CLI\ExitException;
 
+/**
+ * Class MigrationHelper.
+ */
 class MigrationHelper implements InterfaceCommand {
-	private function __construct() {
-		// Do nothing.
-	}
-
 	/**
 	 * Get Instance.
 	 *
@@ -28,11 +27,15 @@ class MigrationHelper implements InterfaceCommand {
 	}
 
 	/**
-	 * @throws Exception
+	 * Register commands.
+	 *
+	 * @throws Exception When WP_CLI::add_command fails.
 	 */
 	public function register_commands(): void {
-		WP_CLI::add_command( 'newspack-content-migrator migration-helper-output-batched',
-			[ $this, 'cmd_output_batched' ], [
+		WP_CLI::add_command(
+			'newspack-content-migrator migration-helper-output-batched',
+			[ $this, 'cmd_output_batched' ],
+			[
 				'shortdesc' => 'Outputs commands batched. Only outputs the command strings – will not run any of the commands.',
 				'synopsis'  => [
 					[
@@ -90,7 +93,12 @@ class MigrationHelper implements InterfaceCommand {
 	}
 
 	/**
-	 * @throws ExitException
+	 * Outputs commands batched. Only outputs the command strings – will not run any of the commands.
+	 *
+	 * @param array $positional_args Positional args.
+	 * @param array $assoc_args Associative args.
+	 *
+	 * @throws ExitException When WP_CLI::runcommand fails.
 	 */
 	public function cmd_output_batched( array $positional_args, array $assoc_args ): void {
 		$begin_at       = $assoc_args['begin-at'] ?? 0;
@@ -128,17 +136,26 @@ class MigrationHelper implements InterfaceCommand {
 				WP_CLI::out( $command_string );
 			}
 
-			WP_CLI::out( self::get_batch_string( $start_arg_name, $end_arg_name, $batch_start, $batch_end )  );
+			WP_CLI::out( self::get_batch_string( $start_arg_name, $end_arg_name, $batch_start, $batch_end ) );
 
 			if ( $iterm_trigger ) {
 				WP_CLI::line( sprintf( ' && echo "MigrationHelper says:___%s___"', $batch_info ) );
 			} else {
-				WP_CLI::line( '' ); // Just to add a newline for ease of copypasta
+				WP_CLI::line( '' ); // Just to add a newline for ease of copypasta.
 			}
-
 		}
 	}
 
+	/**
+	 * Get batch string.
+	 *
+	 * @param string $start_arg_name Start arg name.
+	 * @param string $end_arg_name End arg name.
+	 * @param int    $start Start.
+	 * @param int    $end End.
+	 *
+	 * @return string
+	 */
 	public static function get_batch_string( string $start_arg_name, string $end_arg_name, int $start, int $end ): string {
 		$batch_string = '';
 

--- a/src/Command/General/MigrationHelper.php
+++ b/src/Command/General/MigrationHelper.php
@@ -120,16 +120,14 @@ class MigrationHelper implements InterfaceCommand {
 			$command_string = $command . " \\\n" . $command_args . " \\\n";
 		}
 
-		if ( $begin_at > 0 ) {
-			$total_items = $total_items - $begin_at;
-		}
-		$num_batches = ceil( $total_items / $batch_size );
+		$total_batched_items = $begin_at > 0 ? $total_items - $begin_at : $total_items;
+		$num_batches         = ceil( $total_batched_items / $batch_size );
 
 		for ( $batch = 0; $batch < $num_batches; $batch ++ ) {
 			$batch_start = ( $batch * $batch_size ) + $begin_at;
 			$batch_end   = $batch_start + $batch_size;
 			if ( $batch_end > $total_items ) {
-				$batch_end = 0;
+				$batch_end = $total_items + 1;
 			}
 			$batch_info = sprintf( 'Batch %d of %d', $batch + 1, $num_batches );
 			WP_CLI::line( sprintf( PHP_EOL . '# MigrationHelper: %s', $batch_info ) );

--- a/src/Command/General/MigrationHelper.php
+++ b/src/Command/General/MigrationHelper.php
@@ -127,7 +127,7 @@ class MigrationHelper implements InterfaceCommand {
 			$batch_start = ( $batch * $batch_size ) + $begin_at;
 			$batch_end   = $batch_start + $batch_size;
 			if ( $batch_end > $total_items ) {
-				$batch_end = $total_items + 1;
+				$batch_end = $total_items;
 			}
 			$batch_info = sprintf( 'Batch %d of %d', $batch + 1, $num_batches );
 			WP_CLI::line( sprintf( PHP_EOL . '# MigrationHelper: %s', $batch_info ) );

--- a/src/Command/General/MigrationHelper.php
+++ b/src/Command/General/MigrationHelper.php
@@ -115,7 +115,8 @@ class MigrationHelper implements InterfaceCommand {
 			}
 			$command        = $matches[1];
 			$command_args   = trim( str_replace( $command, '', $command_string ) );
-			$command_args   = trim( preg_replace( '/\s+/', " \\\n", $command_args ), '\\' );
+			$command_args   = \WP_CLI\Utils\parse_str_to_argv( $command_args );
+			$command_args   = implode( " \\\n", $command_args );
 			$command_string = $command . " \\\n" . $command_args . " \\\n";
 		}
 


### PR DESCRIPTION
This PR makes it possible to have commands with space in their parameter values and fix the counting of the `end` parameter.

## How to test
- Run the following command `wp newspack-content-migrator migration-helper-output-batched 'wp newspack-content-migrator my-custom-migrator --param1=123 --param2="filename with space.zip"' --total-items=20 --batch-size=2 --begin-at=5`
- Notice the generated commands are breaking for the parameter with space `param2`
- Notice the three last commands don't have an `end` parameter.
- Pull this branch.
- Run the same command.
- Notice that the commands are generated with the spaced parameter on one line.
- Notice the `end` parameter is set to all the commands.

---

- [x] confirmed that PHPCS has been run
