### PR TITLE
Feat/embarcadero add QA command

### DIFF
--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -3170,7 +3170,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 
 						$content = str_replace( $match['shortcode'], $media_content, $content );
 					} else {
-						$this->logger->log( self::LOG_FILE, sprintf( 'Could not find map %s for the post %d', $match['id'], $wp_post_id ), Logger::WARNING );
+						$this->logger->log( self::LOG_FILE, sprintf( 'Could not find map %s for the post %d', ( $match['id'] ?? '' ), $wp_post_id ), Logger::WARNING );
 					}
 					break;
 				case 'timeline':

--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -785,6 +785,37 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 				],
 			]
 		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator embarcadero-post-launch-qa',
+			array( $this, 'cmd_embarcadero_post_launch_qa' ),
+			[
+				'shortdesc' => 'Check for migration issues after the launch.',
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'story-photos-file-paths',
+						'description' => 'Path to the CSV files separated by a comma containing the stories\'s photos to import (e.g. export/file1.csv,export/file2.csv).',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'story-media-file-paths',
+						'description' => 'Path to the CSV files separated by a comma containing the stories\'s media to import (e.g. export/file1.csv,export/file2.csv).',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'story-carousel-items-dir-paths',
+						'description' => 'Path to the CSV files separated by a comma containing the stories\'s carousel items to import (e.g. export/file1.csv,export/file2.csv).',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -1316,6 +1347,188 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 				$this->logger->log( self::LOG_FILE, sprintf( 'Updated post %d with the ID %d', $index + 1, $post->ID ), Logger::SUCCESS );
 			}
 		}
+	}
+
+	/**
+	 * Callable for "newspack-content-migrator embarcadero-post-launch-qa".
+	 *
+	 * @param array $args array Command arguments.
+	 * @param array $assoc_args array Command associative arguments.
+	 */
+	public function cmd_embarcadero_post_launch_qa( $args, $assoc_args ) {
+		global $wpdb;
+
+		$story_photos_csv_file_paths    = $assoc_args['story-photos-file-paths'];
+		$story_media_csv_file_paths     = $assoc_args['story-media-file-paths'];
+		$story_carousel_items_dir_paths = $assoc_args['story-carousel-items-dir-paths'];
+
+		$photos = array_reduce(
+			explode( ',', $story_photos_csv_file_paths ),
+			function ( $carry, $item ) {
+				return array_merge( $carry, $this->get_data_from_csv_or_tsv( $item ) );
+			},
+			[]
+		);
+
+		$media = array_reduce(
+			explode( ',', $story_media_csv_file_paths ),
+			function ( $carry, $item ) {
+				return array_merge( $carry, $this->get_data_from_csv_or_tsv( $item ) );
+			},
+			[]
+		);
+
+		$carousel_items = array_reduce(
+			explode( ',', $story_carousel_items_dir_paths ),
+			function ( $carry, $item ) {
+				return array_merge( $carry, $this->get_data_from_csv_or_tsv( $item ) );
+			},
+			[]
+		);
+
+		// QA Content Styling.
+		$content_styling_shortcodes = [ '==I', '==B', '==BI', '==SH' ];
+
+		// Get all the posts with the content styling shortcodes.
+		foreach ( $content_styling_shortcodes as $shortcode ) {
+			$posts = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT ID, post_content FROM {$wpdb->posts} WHERE post_status = 'publish' AND post_content LIKE %s",
+					'%' . $shortcode . '%'
+				)
+			);
+
+			$this->logger->log( self::LOG_FILE, sprintf( 'Found %d posts with the shortcode "%s"', count( $posts ), $shortcode ), Logger::INFO );
+
+			foreach ( $posts as $post ) {
+				$regex = '/(?<shortcode>(' . $shortcode . '\s+(.*?)==)|(' . $shortcode . '\s+(.*?)\n))/';
+				preg_match_all( $regex, $post->post_content, $matches );
+
+				if ( ! empty( $matches['shortcode'] ) ) {
+					$this->logger->log( self::LOG_FILE, sprintf( 'Trying to fix post with the ID %d for the shortcode: %s', $post->ID, $shortcode ), Logger::INFO );
+					$fixed_content = $this->migrate_text_styling( $post->post_content );
+
+					preg_match_all( $regex, $fixed_content, $after_fix_matches );
+
+					if ( ! empty( $after_fix_matches['shortcode'] ) ) {
+						$matches_per_line = array_reduce(
+							$after_fix_matches[0],
+							function ( $carry, $item ) {
+								return $carry . "\n" . $item;
+							},
+							''
+						);
+						$this->logger->log( self::LOG_FILE, sprintf( 'Could not fix post with the ID %d for the shortcode "%s": %s', $post->ID, $shortcode, $matches_per_line ), Logger::ERROR );
+					} else {
+						$this->logger->log( self::LOG_FILE, sprintf( 'Fixed post with the ID %d for the shortcode: %s', $post->ID, $shortcode ), Logger::SUCCESS );
+						wp_update_post(
+							[
+								'ID'           => $post->ID,
+								'post_content' => $fixed_content,
+							]
+						);
+					}
+				} else {
+					// Probably a false positive.
+					$highlighted_results = $this->highlight_text( $post->post_content, $shortcode );
+
+					foreach ( $highlighted_results as $result ) {
+						$this->logger->log( self::LOG_FILE, "Found a false positive for the shortcode '$shortcode' in the post with the ID {$post->ID}: $result", Logger::WARNING );
+					}
+				}
+			}
+		}
+
+		// QA Content Shortcodes.
+		$content_shortcodes = [ 'carousel', 'flour', 'map', 'more_stories', 'pull_quote', 'timeline', 'video' ];
+		foreach ( $content_shortcodes as $shortcode ) {
+			$posts = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT ID, post_content FROM {$wpdb->posts} WHERE post_status = 'publish' AND post_content LIKE %s",
+					'%{' . $shortcode . '%'
+				)
+			);
+
+			$this->logger->log( self::LOG_FILE, sprintf( 'Found %d posts with the shortcode "%s"', count( $posts ), $shortcode ), Logger::INFO );
+
+			foreach ( $posts as $post ) {
+				$regex = '/(?<shortcode>{(?<type>' . $shortcode . ')(\s+(?<width>(\d|\w)+)?)?(\s+(?<id>\d+)?)?})/';
+				preg_match_all( $regex, $post->post_content, $matches );
+
+				if ( ! empty( $matches['shortcode'] ) ) {
+					$this->logger->log( self::LOG_FILE, sprintf( 'Trying to fix post with the ID %d for the shortcode: %s', $post->ID, $shortcode ), Logger::INFO );
+
+					$story_id      = get_post_meta( $post->ID, self::EMBARCADERO_ORIGINAL_ID_META_KEY, true );
+					$fixed_content = $this->migrate_media( $post->ID, $story_id, $post->post_content, $media, $photos, '/tmp', $carousel_items );
+
+					preg_match_all( $regex, $fixed_content, $after_fix_matches );
+
+					if ( ! empty( $after_fix_matches['shortcode'] ) ) {
+						$matches_per_line = array_reduce(
+							$after_fix_matches[0],
+							function ( $carry, $item ) {
+								return $carry . "\n" . $item;
+							},
+							''
+						);
+						$this->logger->log( self::LOG_FILE, sprintf( 'Could not fix post with the ID %d for the shortcode "%s": %s', $post->ID, $shortcode, $matches_per_line ), Logger::ERROR );
+					} else {
+						$this->logger->log( self::LOG_FILE, sprintf( 'Fixed post with the ID %d for the shortcode: %s', $post->ID, $shortcode ), Logger::SUCCESS );
+						wp_update_post(
+							[
+								'ID'           => $post->ID,
+								'post_content' => $fixed_content,
+							]
+						);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Search for a string in a text and highlight the results.
+	 *
+	 * @param string $text Text to search in.
+	 * @param string $search String to search for.
+	 * @param int    $chars_to_show Number of characters to show before and after the search text.
+	 *
+	 * @return array Array of highlighted results.
+	 */
+	private function highlight_text( $text, $search, $chars_to_show = 10 ) {
+		$position = 0;
+		$results  = [];
+
+		$search_length = strlen( $search );
+
+		// Loop through all occurrences of the search text.
+		while ( ( $position = strpos( $text, $search, $position ) ) !== false ) {
+			// Calculate start position to show few chars before the search text.
+			$start = $position - $chars_to_show;
+			if ( $start < 0 ) {
+				$start = 0;
+			}
+
+			// Calculate the length to show search text + few chars after.
+			$length = $chars_to_show + $search_length + $chars_to_show;
+
+			// Extract the substring.
+			$extracted = substr( $text, $start, $length );
+
+			// Highlight the search text.
+			$color               = '%G';
+			$colorized_shortcode = \cli\Colors::colorize( "$color$search%n" );
+			$highlighted         = str_replace( $search, $colorized_shortcode, trim( preg_replace( '/\s+/', ' ', $extracted ) ) );
+
+			// Save the result.
+			$results[] = $highlighted;
+
+			// Move position forward to find next occurrence.
+			$position = $position + $search_length;
+		}
+
+		// Return highlighted results.
+		return $results;
 	}
 
 	/**

--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -2915,7 +2915,19 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 					}
 					break;
 				case 'timeline':
-					$this->logger->log( self::LOG_FILE, sprintf( 'Timeline shortcode found for the post %d', $wp_post_id ), Logger::WARNING );
+					$media_index = array_search( $match['id'], array_column( $media_list, 'media_id' ) );
+					if ( false !== $media_index ) {
+						$timeline_media = $media_list[ $media_index ];
+
+						if ( str_starts_with( $timeline_media['media_link'], '<iframe' ) ) {
+							$photo_block_html = serialize_block( $this->gutenberg_block_generator->get_html( $timeline_media['media_link'] ) );
+							$content          = str_replace( $match['shortcode'], $photo_block_html, $content );
+						} else {
+							$this->logger->log( self::LOG_FILE, sprintf( 'Could not find iframe code for the post %d', $wp_post_id ), Logger::WARNING );
+						}
+					} else {
+						$this->logger->log( self::LOG_FILE, sprintf( 'Could not find media for the timeline %s for the post %d', $match['id'], $wp_post_id ), Logger::WARNING );
+					}
 					break;
 				case 'video':
 					$media_index = array_search( $match['id'], array_column( $media_list, 'media_id' ) );

--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -4,14 +4,13 @@ namespace NewspackCustomContentMigrator\Command\General;
 
 use DateTimeZone;
 use DOMDocument;
-use DOMNode;
 use NewspackCustomContentMigrator\Command\InterfaceCommand;
 use NewspackCustomContentMigrator\Utils\Logger;
 use NewspackCustomContentMigrator\Logic\Attachments;
-use \NewspackCustomContentMigrator\Logic\CoAuthorPlus;
-use \NewspackCustomContentMigrator\Logic\GutenbergBlockGenerator;
+use NewspackCustomContentMigrator\Logic\CoAuthorPlus;
+use NewspackCustomContentMigrator\Logic\GutenbergBlockGenerator;
 use NewspackCustomContentMigrator\Utils\WordPressXMLHandler;
-use \WP_CLI;
+use WP_CLI;
 
 /**
  * This class implements the logic for migrating content from Embarcadero custom CMS.
@@ -863,7 +862,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			$posts = array_values(
 				array_filter(
 					$posts,
-					function( $post ) use ( $imported_original_ids ) {
+					function ( $post ) use ( $imported_original_ids ) {
 						return ! in_array( $post['story_id'], $imported_original_ids );
 					}
 				)
@@ -886,7 +885,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 
 			// phpcs:ignore
 			$story_text         = str_replace( "\n", "</p>\n<p>", '<p>' . $post['story_text'] . '</p>' );
-
 
 			$post_data = [
 				'post_title'   => $post['headline'],
@@ -981,7 +979,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 					);
 				} else {
 					$co_author_nicenames = array_map(
-						function( $co_author_user ) {
+						function ( $co_author_user ) {
 							return $co_author_user->user_nicename;
 						},
 						$co_author_users
@@ -1129,7 +1127,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$featured_photos = array_values(
 			array_filter(
 				$photos,
-				function( $photo ) use ( $imported_original_ids ) {
+				function ( $photo ) use ( $imported_original_ids ) {
 					return 'yes' === $photo['feature'] && ! in_array( $photo['photo_id'], $imported_original_ids );
 				}
 			)
@@ -1204,7 +1202,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$story_csv_file_path = $assoc_args['story-csv-file-path'];
 		$index_from          = isset( $assoc_args['index-from'] ) ? intval( $assoc_args['index-from'] ) : 0;
 		$index_to            = isset( $assoc_args['index-to'] ) ? intval( $assoc_args['index-to'] ) : -1;
-
 
 		$posts    = $this->get_data_from_csv_or_tsv( $story_csv_file_path );
 		$log_file = 'fix-post-times.log';
@@ -1549,7 +1546,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$posts = array_values(
 			array_filter(
 				$posts,
-				function( $post ) use ( $imported_original_ids ) {
+				function ( $post ) use ( $imported_original_ids ) {
 					return ! in_array( $post['story_id'], $imported_original_ids );
 				}
 			)
@@ -1574,7 +1571,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			$more_stories_media = array_values(
 				array_filter(
 					$media_list,
-					function( $media_item ) use ( $post ) {
+					function ( $media_item ) use ( $post ) {
 						return $media_item['story_id'] === $post['story_id'] && 'more_stories' === $media_item['media_type'];
 					}
 				)
@@ -1629,7 +1626,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$posts = array_values(
 			array_filter(
 				$posts,
-				function( $post ) use ( $imported_original_ids ) {
+				function ( $post ) use ( $imported_original_ids ) {
 					return in_array( $post['story_id'], $imported_original_ids );
 				}
 			)
@@ -1652,7 +1649,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			$more_stories_media = array_values(
 				array_filter(
 					$media_list,
-					function( $media_item ) use ( $post ) {
+					function ( $media_item ) use ( $post ) {
 						return $media_item['story_id'] === $post['story_id'] && 'more_stories' === $media_item['media_type'];
 					}
 				)
@@ -1694,7 +1691,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 					if (
 						'core/paragraph' === $content_blocks[ $i ]['blockName']
 						&& str_starts_with( $content_blocks[ $i ]['innerHTML'], '<p><strong><a href="' )
-						 ) {
+						) {
 						$indexes_to_remove[] = $i;
 					} else {
 						break;
@@ -1857,7 +1854,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$comments = array_values(
 			array_filter(
 				$comments,
-				function( $comment ) use ( $imported_original_ids ) {
+				function ( $comment ) use ( $imported_original_ids ) {
 					return ! in_array( $comment['comment_id'], $imported_original_ids );
 				}
 			)
@@ -1908,7 +1905,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 					$wp_user = get_user_by( 'id', $wp_user_id );
 				}
 			}
-
 
 			$comment_data = [
 				'comment_post_ID'      => $wp_post_id,
@@ -2042,8 +2038,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 				$post_content_blocks[] = $this->gutenberg_block_generator->get_file_pdf( $attachment_post, $section_name );
 			}
 
-
-
 			$post_content = serialize_blocks( $post_content_blocks );
 
 			wp_update_post(
@@ -2098,7 +2092,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$stories = array_values(
 			array_filter(
 				$stories,
-				function( $story ) use ( $imported_original_ids ) {
+				function ( $story ) use ( $imported_original_ids ) {
 					return ! in_array( $story['story_id'], $imported_original_ids );
 				}
 			)
@@ -2264,7 +2258,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			) {
 				if ( count( $tsv_row ) !== count( $csv_headers ) ) {
 					WP_CLI::warning( sprintf( 'Can not read CSV row beginning with >>> %s <<<', substr( $tsv_row[0], 0, 50 ) ) );
-					$wrong_rows ++;
+					++$wrong_rows;
 				}
 			}
 		} while ( true !== $fixed );
@@ -2821,7 +2815,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 			);
 		}
 
-
 		return $wp_user_id;
 	}
 
@@ -3046,7 +3039,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 
 						$media_carousel_items = array_filter(
 							$carousel_items,
-							function( $carousel_item ) use ( $media ) {
+							function ( $carousel_item ) use ( $media ) {
 								return $carousel_item['carousel_media_id'] === $media['media_id'];
 							}
 						);
@@ -3054,7 +3047,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 						// order $media_carousel_items by sort_order column.
 						usort(
 							$media_carousel_items,
-							function( $a, $b ) {
+							function ( $a, $b ) {
 								return intval( $a['sort_order'] ) <=> intval( $b['sort_order'] );
 							}
 						);
@@ -3062,7 +3055,7 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 						$carousel_attachments_items = array_values(
 							array_filter(
 								array_map(
-									function( $carousel_item ) use ( $wp_post_id, $photos, $story_photos_dir_path ) {
+									function ( $carousel_item ) use ( $wp_post_id, $photos, $story_photos_dir_path ) {
 										$photo_index = array_search( $carousel_item['photo_id'], array_column( $photos, 'photo_id' ) );
 										if ( false !== $photo_index ) {
 											$photo         = $photos[ $photo_index ];
@@ -3075,8 +3068,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 												return null;
 											}
 										}
-
-
 									},
 									$media_carousel_items
 								)
@@ -3171,7 +3162,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 						$this->logger->log( self::LOG_FILE, sprintf( 'Could not find video %s for the post %d', $match['id'], $wp_post_id ), Logger::WARNING );
 					}
 					break;
-					break;
 				case 'pull_quote':
 					// pull quotes are in the format: {pull_quote  659}.
 					$media_index = array_search( intval( $match['width'] ), array_column( $media_list, 'media_id' ) );
@@ -3219,7 +3209,6 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 		$story_text = preg_replace( '/==BI\s+(.*?)==/', '<strong><em>${1}</em></strong>', $story_text );
 		// Same goes for sub header.
 		$story_text = preg_replace( '/==SH\s+(.*?)==/', '<h3>${1}</h3>', $story_text );
-
 
 		// The content contain some styling in the format ==I whatever text here should be italic\n.
 		// We need to convert them to <em>whatever text here should be italic</em>.

--- a/src/Utils/Logger.php
+++ b/src/Utils/Logger.php
@@ -7,7 +7,7 @@
 
 namespace NewspackCustomContentMigrator\Utils;
 
-use \WP_CLI;
+use WP_CLI;
 
 /**
  * Class for handling commands' logging
@@ -20,6 +20,7 @@ class Logger {
 	const LINE    = 'line';
 	const SUCCESS = 'success';
 	const ERROR   = 'error';
+	const INFO    = 'info';
 
 	/**
 	 * Determine the writeable directory used for storing logs created by migration commands.
@@ -34,7 +35,6 @@ class Logger {
 		}
 
 		return $log_dir . DIRECTORY_SEPARATOR . $filename . '.log';
-
 	}
 
 	/**
@@ -65,13 +65,21 @@ class Logger {
 				case ( self::ERROR ):
 					WP_CLI::error( $message, $exit_on_error );
 					break;
+				case ( self::INFO ):
+					$label = 'Info';
+					if ( class_exists( 'cli\Colors' ) ) {
+						$color = '%B';
+						$label = \cli\Colors::colorize( "$color$label:%n", true );
+					} else {
+						$label = "$label:";
+					}
+					WP_CLI::line( "$label $message" );
+					break;
 				case ( self::LINE ):
 				default:
 					WP_CLI::line( $message );
 					break;
 			}
 		}
-
 	}
-
 }


### PR DESCRIPTION
This PR adds a QA command to run on the Embarcadero sites post-launch:

```shell
 wp newspack-content-migrator embarcadero-post-launch-qa \
--story-csv-file-paths=/new_export/story.csv,/old_export/old_files/story.csv,/new_export/story_1.csv,/old_export/old_files/story_1.csv \
--story-photos-file-paths=/new_export/story_photos.csv,/old_export/old_files/story_photos.csv \
--story-media-file-paths=/new_export/story_media.csv,/old_export/old_files/story_media.csv \
--story-carousel-items-dir-paths=/new_export/story_carousel_items.csv,/old_export/old_files/story_carousel_items.csv
```

It also adds the `INFO` level for the logger :)

---

- [x] confirmed that PHPCS has been run
