### PR TITLE
Add and remove filter in wrapper for image urls

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -385,4 +385,30 @@ class Attachments {
 
 		return $attachment_id;
 	}
+
+	/**
+	 * This helper wraps the `wp_get_attachment_image_src()` function to bypass Jetpack's Photon.
+	 *
+	 * We don't want the CDN urls in migration data because they are harder to replace later.
+	 *
+	 * @param int $attachment_id The attachment ID.
+	 * @param string $size The image size.
+	 * @param bool $icon Whether the image should be an icon.
+	 *
+	 * @return array|false
+	 */
+	public static function get_attachment_image_src( $attachment_id, $size = 'thumbnail', $icon = false ) {
+		static $filter_callback = null;
+		if ( null === $filter_callback ) {
+			$filter_callback = function ( $skip, $image_url, $args, $scheme ) {
+				return true;
+			};
+		}
+		add_filter( 'jetpack_photon_skip_for_url', $filter_callback, 10, 4 );
+		$src = wp_get_attachment_image_src( $attachment_id, $size, $icon );
+		remove_filter( 'jetpack_photon_skip_for_url', $filter_callback );
+
+		return $src;
+	}
+
 }

--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -262,7 +262,7 @@ class GutenbergBlockGenerator {
 
 		$caption_tag   = ! empty( $attachment_post->post_excerpt ) ? '<figcaption class="wp-element-caption">' . $attachment_post->post_excerpt . '</figcaption>' : '';
 		$image_alt     = get_post_meta( $attachment_post->ID, '_wp_attachment_image_alt', true );
-		$image_url     = wp_get_attachment_image_src( $attachment_post->ID, $size )[0];
+		$image_url     = Attachments::get_attachment_image_src( $attachment_post->ID, $size )[0];
 		$attachment_id = intval( $attachment_post->ID );
 
 		$attrs = [


### PR DESCRIPTION
This to avoid CDN urls in migrations

## How to test
On a site that is connected to Jetpack, first run this to verify that you get a cdn url:
`wp eval "var_dump(wp_get_attachment_image_src( 71044, 'full'));"`

Then test the new function that wraps:
` wp eval "var_dump(\NewspackCustomContentMigrator\Logic\Attachments::get_attachment_image_src( 71044, 'full'));"`
you should now _not_ be getting a CDN url. 

We can likely use this function from more places than the Block Generator where I wanted it fixed, but let's start with this.

---


