### PR TITLE
Village Media CMS -- fix post authors

### DIFF
--- a/src/Command/General/VillageMediaCMSMigrator.php
+++ b/src/Command/General/VillageMediaCMSMigrator.php
@@ -314,6 +314,8 @@ class VillageMediaCMSMigrator implements InterfaceCommand {
 				}
 			}
 		}
+
+		WP_CLI::warning( 'NOTE -- make sure to run `newspack-content-migrator village-cms-fix-authors` to properly assign all authors.' );
 	}
 
 	/**

--- a/src/Command/General/VillageMediaCMSMigrator.php
+++ b/src/Command/General/VillageMediaCMSMigrator.php
@@ -150,6 +150,13 @@ class VillageMediaCMSMigrator implements InterfaceCommand {
 						'optional'    => true,
 						'repeating'   => false,
 					],
+					[
+						'type'        => 'flag',
+						'name'        => 'dev-only-update-bylines',
+						'description' => 'Dev helper flag. If it is set, will only update coauthors where byline attribute is set, not where author node is set.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
 				],
 			]
 		);
@@ -645,6 +652,7 @@ class VillageMediaCMSMigrator implements InterfaceCommand {
 		if ( isset( $assoc_args['bylines-special-cases-php-file'] ) && file_exists( $assoc_args['bylines-special-cases-php-file'] ) ) {
 			$bylines_special_cases = include $assoc_args['bylines-special-cases-php-file'];
 		}
+		$dev_only_update_bylines = $assoc_args['dev-only-update-bylines'] ?? null;
 		
 
 		// Loop through content nodes and fix authors.
@@ -760,7 +768,7 @@ class VillageMediaCMSMigrator implements InterfaceCommand {
 					$this->cap->assign_authors_to_post( $wp_users, $post_id, false );
 					$this->logger->log( $log, sprintf( 'Assigned CAP WP_User IDs %s to post_ID %d', implode( ',', $wp_user_ids_after ), $post_id ) );
 				}           
-			} else {
+			} elseif ( ! $dev_only_update_bylines ) {
 
 				/**
 				 * Use <author> as author.
@@ -1099,7 +1107,7 @@ class VillageMediaCMSMigrator implements InterfaceCommand {
 		$author_names = [];
 			
 		// Replace multiple separators with a common separator.
-		$separators       = [ ', and', ',', ' and ', ' with ', ' & ' ];
+		$separators       = [ ', and', ',', ' and ', ' with ', ' & ', ' y ' ];
 		$common_separator = '&&';
 		$byline_replaced  = str_replace( $separators, $common_separator, $byline );
 

--- a/src/Logic/CoAuthorPlus.php
+++ b/src/Logic/CoAuthorPlus.php
@@ -7,9 +7,10 @@
 
 namespace NewspackCustomContentMigrator\Logic;
 
-use \CoAuthors_Plus;
-use \CoAuthors_Guest_Authors;
-use \WP_CLI;
+use CoAuthors_Plus;
+use CoAuthors_Guest_Authors;
+use WP_CLI;
+use WP_Error;
 use WP_Post;
 
 /**
@@ -176,7 +177,7 @@ class CoAuthorPlus {
 		}
 
 		// Create a unique user_login one and return that if it's not taken.
-		$unique_user_login           = sprintf( '%s_%s', $user_login, $this->generate_random_string() );
+		$unique_user_login = sprintf( '%s_%s', $user_login, $this->generate_random_string() );
 		// phpcs:disable -- Allow querying users table.
 		$unique_wpuser_login_exists  = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->users WHERE user_login = %s", $unique_user_login ) );
 		// phpcs:ensable
@@ -302,12 +303,24 @@ class CoAuthorPlus {
 	 * @param bool  $append_to_existing_users Append to existing Guest Authors.
 	 */
 	public function assign_guest_authors_to_post( array $guest_author_ids, $post_id, bool $append_to_existing_users = false ) {
+		$coauthors_user_nicenames = [];
 		$coauthors = [];
 		foreach ( $guest_author_ids as $guest_author_id ) {
-			$guest_author = $this->coauthors_guest_authors->get_guest_author_by( 'id', $guest_author_id );
-			$coauthors[]  = $guest_author->user_nicename;
+			$guest_author               = $this->coauthors_guest_authors->get_guest_author_by( 'id', $guest_author_id );
+
+			$coauthors_user_nicenames[] = $guest_author->user_nicename;
+			$coauthors[]                = $guest_author->user_nicename;
 		}
-		$this->coauthors_plus->add_coauthors( $post_id, $coauthors, $append_to_existing_users );
+		$this->coauthors_plus->add_coauthors( $post_id, $coauthors_user_nicenames, $append_to_existing_users );
+
+		// Validate if the authors were assigned correctly.
+		$valid = $this->validate_authors_for_post( $post_id, $coauthors );
+		if ( is_wp_error( $valid ) ) {
+			$ga_ids = array_map( function( $author ) {
+				return $author->ID;
+			}, $coauthors );
+			throw new \RuntimeException( sprintf( 'Failed to assign guest author IDs %s to post ID %d. Error: %s', implode( ',', $ga_ids ), $post_id, $valid->get_error_message() ) );
+		}
 	}
 
 	/**
@@ -318,6 +331,7 @@ class CoAuthorPlus {
 	 * @param bool  $append_to_existing_users Append to existing Guest Authors.
 	 *
 	 * @throws \UnexpectedValueException If $authors contains an unsupported class.
+	 * @throws \RuntimeException         If authors were not assigned correctly.
 	 */
 	public function assign_authors_to_post( array $authors, $post_id, bool $append_to_existing_users = false ) {
 		$coauthors_nicenames = [];
@@ -331,6 +345,125 @@ class CoAuthorPlus {
 			}
 		}
 		$this->coauthors_plus->add_coauthors( $post_id, $coauthors_nicenames, $append_to_existing_users );
+		
+		// Validate if the authors were assigned correctly.
+		$valid = $this->validate_authors_for_post( $post_id, $authors );
+		if ( is_wp_error( $valid ) ) {
+			$author_ids = array_map( function( $author ) {
+				return $author->ID;
+			}, $authors );
+			throw new \RuntimeException( sprintf( 'Failed to assign author IDs %s to post ID %d. Error: %s', implode( ',', $author_ids ), $post_id, $valid->get_error_message() ) );
+		}
+	}
+
+	/**
+	 * Validates if expected authors (or author names) are assigned to post.
+	 *
+	 * @param int $post_id                     Post ID.
+	 * @param array $author_names              Array of author objects (either WP_User or CAP GA objects) or just author display_names.
+	 * @param boolean $strict_order_or_authors Optional. Should the order of authors be observed strictly? Default is yes/true.
+	 * @return boolean|WP_Error                True if authors/author names are as expected, WP_Error if not.
+	 */
+	public function validate_authors_for_post( int $post_id, array $authors_expected, bool $strict_order_or_authors = true ): bool|WP_Error {
+
+		// Get actual authors. If no GAs are assigned to post, get WP Post author.
+		$authors_actual = $this->get_all_authors_for_post( $post_id );
+		if ( ! $authors_actual ) {
+			$wp_post = get_post( $post_id );
+			$authors_actual = [ get_userdata( $wp_post->post_author ) ];
+		}
+
+		// If number of authors is different, return error.
+		if ( count( $authors_expected ) !== count( $authors_actual ) ) {
+			return new WP_Error( sprintf( 'Post ID %d does not have the expected number of authors which is %d.', $post_id, count( $authors_expected ) ) );
+		}
+
+		// Validate expected authors.
+		foreach ( $authors_expected as $key_author_expected => $author_expected ) {
+			
+			// If $strict_order_of_authors is true, also check exact author position.
+			if ( true === $strict_order_or_authors ) {
+				
+				$author_actual = $authors_actual[ $key_author_expected ];
+				if ( is_object( $author_expected ) ) {
+					$does_name_match = $author_expected->display_name == $author_actual->display_name;
+					if ( ! $does_name_match ) {
+						return new WP_Error( sprintf( "Post ID %d author index %d actual author display_name '%s' is different from expected display name '%s'.", $post_id, $key_author_expected, $author_actual->display_name, $author_expected->display_name ) );
+					}
+					$does_ID_match = $author_expected->ID == $author_actual->ID;
+					if ( ! $does_ID_match ) {
+						return new WP_Error( sprintf( "Post ID %d author index %d actual author ID %d is different than expected object ID %d.", $post_id, $key_author_expected, $author_actual->ID, $author_expected->ID ) );
+					}
+				} elseif ( is_string( $author_expected ) ) {
+					$does_name_match = $author_expected == $author_actual->display_name;
+					if ( ! $does_name_match ) {
+						return new WP_Error( sprintf( "Post ID %d author index %d actual author display_name '%s' is different from expected display name '%s'.", $post_id, $key_author_expected, $author_actual->display_name, $author_expected ) );
+					}
+				} else {
+					return new WP_Error( sprintf( 'Expected author index %d is neither WP_User, nor GAP GA object, nor display_name string.', $key_author_expected ) );
+				}
+
+			} else {
+
+				// If not observing strict order of authors, just check if the author names are present in the list of authors.
+				if ( is_object( $author_expected ) ) {
+					$does_name_match = in_array( $author_expected->display_name, array_column($authors_actual, 'display_name' ) );
+					if ( ! $does_name_match ) {
+						return new WP_Error( sprintf( "Expected author index '%s' and display_name '%s' is not an author of post ID %d.", $key_author_expected, $author_expected->display_name, $post_id ) );
+					}
+					$does_ID_match = in_array( $author_expected->ID, array_column($authors_actual, 'ID' ) );
+					if ( ! $does_ID_match ) {
+						return new WP_Error( sprintf( "Expected author index '%s' and ID '%d' is not an author of post ID %d.", $key_author_expected, $author_expected->ID, $post_id ) );
+					}
+				} elseif ( is_string( $author_expected ) ) {
+					$does_name_match = in_array( $author_expected, array_column($authors_actual, 'display_name' ) );
+					if ( ! $does_name_match ) {
+						return new WP_Error( sprintf( "Expected author index '%s' and display_name '%s' is not an author of post ID %d.", $key_author_expected, $author_expected, $post_id ) );
+					}
+				} else {
+					return new WP_Error( sprintf( 'Expected author index %d is neither a WP_User, nor a GAP GA object, nor a string.', $key_author_expected ) );
+				}
+
+			}
+		}
+
+		return true;
+	}
+	/**
+	 * Unassigns all Guest Authors from the Post.
+	 * After running this, the Post will have no Guest Authors, and authorship will be determined by wp_posts.post_author WP_User.
+	 *
+	 * @param integer $post_id Post ID.
+	 * @return void
+	 * @throws \UnexpectedValueException If GA not removed successfully.
+	 */
+	public function unassign_all_guest_authors_from_post( int $post_id ): void {
+		global $wpdb;
+
+		// Get all object relationships for this post where taxonomy is 'author'.
+		$results = $wpdb->get_results( $wpdb->prepare(
+			"select wtr.object_id, wtr.term_taxonomy_id
+			from wp_term_relationships wtr
+			join wp_term_taxonomy wtt on wtt.term_taxonomy_id = wtr.term_taxonomy_id and wtt.taxonomy = 'author'
+			where wtr.object_id = %s;",
+			$post_id
+		), ARRAY_A );
+
+		// Remove these term relationships.
+		foreach ( $results as $result ) {
+			$deleted = $wpdb->delete(
+				$wpdb->term_relationships,
+				[
+					'object_id'        => $result['object_id'],
+					'term_taxonomy_id' => $result['term_taxonomy_id'],
+				]
+			);
+			if ( false === $deleted ) {
+				throw new \RuntimeException( sprintf( 'ERROR -- failed to delete term relationship for post/object ID %d and term taxonomy ID %d.', $result['object_id'], $result['term_taxonomy_id'] ) );
+			}
+		}
+
+		wp_cache_flush();
 	}
 
 	/**
@@ -536,7 +669,6 @@ class CoAuthorPlus {
 		}
 
 		return $guest_author;
-
 	}
 
 	/**


### PR DESCRIPTION
## General reusable code changes
- `src/Logic/CoAuthorPlus.php` now got the [`validate_authors_for_post()` method](https://github.com/Automattic/newspack-custom-content-migrator/pull/449/files#diff-3b3907a8903c8530c7ae54522ed347ac5029ef6eb105bfcc0cc36ff68542261fR367)
  - CAP's built-in functionality to assign GAs to Post does not have a return parameter. This makes validation difficult
  - now executing this validation as a part of every call to these two methods we have for assigning GAs to post, and they will throw an exception if author assignment was not successful. Suggesting to @Automattic/newspack-launch-and-infrastructure that we always use these two methods when assigning GAs, because they now contain validation:
    - `assign_authors_to_post` -- assigns any user objects as guest author (either WP_Users or GA objects)
    - `assign_guest_authors_to_post` -- assigns just GAs as author

## Publisher specific changes
Post authors should not necessarily always be `<author>` (`<author>` is just "post creator", but not necessarily post author...) -- we learned from Embarcadero migration:
- if `byline` attribute exists, use it for author
- if `byline` attribute does not exist, use `<author>` for author

## How to test
- a standalone command `village-cms-fix-authors` can be run to fix already imported posts
- author logic was updated in main import command

---

- [x] confirmed that PHPCS has been run
