### PR TITLE
Remove a few unused migrators from inclusion

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -74,15 +74,12 @@ PluginSetup::register_migrators(
 		Command\General\BlockTransformerCommand::class,
 
 		// Publisher specific, remove when launched.
-		Command\PublisherSpecific\RetroReportMigrator::class,
 		Command\PublisherSpecific\SoccerAmericaMigrator::class,
 		Command\PublisherSpecific\LaSillaVaciaMigrator::class,
 		Command\PublisherSpecific\NewsroomNZMigrator::class,
 		Command\PublisherSpecific\LatinFinanceMigrator::class,
 		Command\PublisherSpecific\InsightCrimeMigrator::class,
 		Command\PublisherSpecific\DallasExaminerMigrator::class,
-		Command\PublisherSpecific\TheEmancipatorMigrator::class,
-		Command\PublisherSpecific\HighCountryNewsMigrator2::class,
 		Command\PublisherSpecific\TheCityMigrator::class,
 		Command\PublisherSpecific\LinkNYCMigrator::class,
 		Command\PublisherSpecific\WindyCityMigrator::class,


### PR DESCRIPTION
This simply removes some publisher migrators that are done.