### PR TITLE
TFE Migrator

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -87,5 +87,6 @@ PluginSetup::register_migrators(
 		Command\PublisherSpecific\CityViewMigrator::class,
 		Command\PublisherSpecific\BigBendSentinelMigrator::class,
 		Command\PublisherSpecific\LAFocusMigrator::class,
+		Command\PublisherSpecific\TheFifthEstateMigrator::class,
 	)
 );

--- a/src/Command/PublisherSpecific/TheFifthEstateMigrator.php
+++ b/src/Command/PublisherSpecific/TheFifthEstateMigrator.php
@@ -62,7 +62,7 @@ class TheFifthEstateMigrator implements InterfaceCommand {
 						'optional'    => true,
 						'repeating'   => false,
 					],
-				]
+				],
 			]
 		);
 	}
@@ -77,12 +77,12 @@ class TheFifthEstateMigrator implements InterfaceCommand {
 
 		$start_time = microtime( true );
 
-		$this->logger->log( $log, sprintf( 'Starting Orders and Customers Deletion %s', date('Y-m-d H:I:s') ) );
+		$this->logger->log( $log, sprintf( 'Starting Orders and Customers Deletion %s', date( 'Y-m-d H:I:s' ) ) );
 
 		foreach ( $this->get_wc_orders() as $order ) {
 			$this->logger->log( $log, sprintf( '[Memory: %s » Time: %s] Deleting Customer %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_customer_id() ) );
 
-			if ( !$dry_run ) {
+			if ( ! $dry_run ) {
 				if ( wp_delete_user( $order->get_customer_id() ) ) {
 					$this->logger->log( $log, sprintf( '✅ Successfully deleted Customer with ID %s', $order->get_customer_id() ), Logger::SUCCESS );
 				} else {
@@ -92,7 +92,7 @@ class TheFifthEstateMigrator implements InterfaceCommand {
 
 			$this->logger->log( $log, sprintf( '[Memory: %s » Time: %s] Deleting Order %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_id() ) );
 
-			if ( !$dry_run ) {
+			if ( ! $dry_run ) {
 				if ( wp_delete_post( $order->get_id() ) ) {
 					$this->logger->log( $log, sprintf( '✅ Successfully deleted Order with ID %s', $order->get_id() ), Logger::SUCCESS );
 				} else {
@@ -101,7 +101,7 @@ class TheFifthEstateMigrator implements InterfaceCommand {
 			}
 		}
 
-		if ($dry_run) {
+		if ( $dry_run ) {
 			$this->logger->log( $log, '⚠️ Dry Run: No deletions have been made.', Logger::SUCCESS );
 		} else {
 			$this->logger->log( $log, '✅ All Orders and their Customers have been successfully deleted!', Logger::SUCCESS );
@@ -112,12 +112,14 @@ class TheFifthEstateMigrator implements InterfaceCommand {
 	 * Get WooCommerce orders
 	 */
 	private function get_wc_orders(): iterable {
-		$ids = wc_get_orders( [
-			'date_created' => '2022-12-22',
-			'status' => 'wc-failed',
-			'return' => 'ids',
-			'limit' => -1,
-		] );
+		$ids = wc_get_orders(
+			[
+				'date_created' => '2022-12-22',
+				'status'       => 'wc-failed',
+				'return'       => 'ids',
+				'limit'        => -1,
+			] 
+		);
 
 		foreach ( $ids as $id ) {
 			yield wc_get_order( $id );

--- a/src/Command/PublisherSpecific/TheFifthEstateMigrator.php
+++ b/src/Command/PublisherSpecific/TheFifthEstateMigrator.php
@@ -9,6 +9,7 @@ namespace NewspackCustomContentMigrator\Command\PublisherSpecific;
 
 use Exception;
 use NewspackCustomContentMigrator\Command\InterfaceCommand;
+use NewspackCustomContentMigrator\Utils\Logger;
 use WP_CLI;
 
 /**
@@ -17,10 +18,17 @@ use WP_CLI;
 class TheFifthEstateMigrator implements InterfaceCommand {
 
 	/**
+	 * Logger.
+	 *
+	 * @var Logger $logger Logger instance.
+	 */
+	private $logger;
+
+	/**
 	 * Private constructor.
 	 */
 	private function __construct() {
-		// Do nothing
+		$this->logger = new Logger();
 	}
 
 	/**
@@ -46,44 +54,75 @@ class TheFifthEstateMigrator implements InterfaceCommand {
 			[ $this, 'cmd_cleanup_orders_from_22_dec_2022' ],
 			[
 				'shortdesc' => 'Cleanup Orders and their related Customers from 22 Dec 2022',
+				'synopsis'  => [
+					[
+						'type'        => 'flag',
+						'name'        => 'dry-run',
+						'description' => 'Do a dry run.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+				]
 			]
 		);
 	}
 
 	/**
-     * Cleanup Orders and their related Customers from 22 Dec 2022.
-     */
-    public function cmd_cleanup_orders_from_22_dec_2022( array $args, array $assoc_args ): void {
-        $start_time = microtime( true );
+	 * Cleanup Orders and their related Customers from 22 Dec 2022.
+	 */
+	public function cmd_cleanup_orders_from_22_dec_2022( array $args, array $assoc_args ): void {
+		$log = 'tfe-cleanup-orders-from-22-dec-2022.log';
 
-        WP_CLI::line( 'Starting Orders and Customers Deletion' );
+		$dry_run = isset( $assoc_args['dry-run'] ) ? true : false;
 
-        foreach ( $this->get_wc_orders() as $order ) {
-            WP_CLI::line( sprintf( '[Memory: %s » Time: %s] Deleting Customer %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_customer_id() ) );
-            wp_delete_user( $order->get_customer_id() );
+		$start_time = microtime( true );
 
-            WP_CLI::line( sprintf( '[Memory: %s » Time: %s] Deleting order %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_id() ) );
-            wp_delete_post( $order->get_id() );
-        }
+		$this->logger->log( $log, sprintf( 'Starting Orders and Customers Deletion %s', date('Y-m-d H:I:s') ) );
 
-        WP_CLI::success( 'All Orders and their Customers have been successfully deleted!' );
-    }
+		foreach ( $this->get_wc_orders() as $order ) {
+			$this->logger->log( $log, sprintf( '[Memory: %s » Time: %s] Deleting Customer %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_customer_id() ) );
 
-    /**
-     * Get WooCommerce orders
-     */
-    private function get_wc_orders(): iterable {
-        $ids = wc_get_orders( [
-            'date_created' => '2022-12-22',
-            'status' => 'wc-failed',
-            'return' => 'ids',
-            'limit' => -1,
-        ] );
+			if ( !$dry_run ) {
+				if ( wp_delete_user( $order->get_customer_id() ) ) {
+					$this->logger->log( $log, sprintf( '✅ Successfully deleted Customer with ID %s', $order->get_customer_id() ), Logger::SUCCESS );
+				} else {
+					$this->logger->log( $log, sprintf( '❌ Could not delete Customer with ID %s', $order->get_customer_id() ), Logger::ERROR );
+				}
+			}
 
-        foreach ( $ids as $id ) {
-            yield wc_get_order( $id );
-        }
+			$this->logger->log( $log, sprintf( '[Memory: %s » Time: %s] Deleting Order %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_id() ) );
 
-        return $ids;
-    }
+			if ( !$dry_run ) {
+				if ( wp_delete_post( $order->get_id() ) ) {
+					$this->logger->log( $log, sprintf( '✅ Successfully deleted Order with ID %s', $order->get_id() ), Logger::SUCCESS );
+				} else {
+					$this->logger->log( $log, sprintf( '❌ Could not delete Order with ID %s', $order->get_id() ), Logger::ERROR );
+				}
+			}
+		}
+
+		if ($dry_run) {
+			$this->logger->log( $log, '⚠️ Dry Run: No deletions have been made.', Logger::SUCCESS );
+		} else {
+			$this->logger->log( $log, '✅ All Orders and their Customers have been successfully deleted!', Logger::SUCCESS );
+		}
+	}
+
+	/**
+	 * Get WooCommerce orders
+	 */
+	private function get_wc_orders(): iterable {
+		$ids = wc_get_orders( [
+			'date_created' => '2022-12-22',
+			'status' => 'wc-failed',
+			'return' => 'ids',
+			'limit' => -1,
+		] );
+
+		foreach ( $ids as $id ) {
+			yield wc_get_order( $id );
+		}
+
+		return $ids;
+	}
 }

--- a/src/Command/PublisherSpecific/TheFifthEstateMigrator.php
+++ b/src/Command/PublisherSpecific/TheFifthEstateMigrator.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Migration tasks for The Fifth Estate.
+ *
+ * @package NewspackCustomContentMigrator
+ */
+
+namespace NewspackCustomContentMigrator\Command\PublisherSpecific;
+
+use Exception;
+use NewspackCustomContentMigrator\Command\InterfaceCommand;
+use WP_CLI;
+
+/**
+ * Custom migration scripts for The Fifth Estate.
+ */
+class TheFifthEstateMigrator implements InterfaceCommand {
+
+	/**
+	 * Private constructor.
+	 */
+	private function __construct() {
+		// Do nothing
+	}
+
+	/**
+	 * Singleton.
+	 *
+	 * @return TheFifthEstateMigrator
+	 */
+	public static function get_instance(): TheFifthEstateMigrator {
+		static $instance = null;
+		if ( null === $instance ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function register_commands(): void {
+		WP_CLI::add_command(
+			'newspack-content-migrator tfe-cleanup-orders-from-22dec2022',
+			[ $this, 'cmd_cleanup_orders_from_22_dec_2022' ],
+			[
+				'shortdesc' => 'Cleanup Orders and their related Customers from 22 Dec 2022',
+			]
+		);
+	}
+
+	/**
+     * Cleanup Orders and their related Customers from 22 Dec 2022.
+     */
+    public function cmd_cleanup_orders_from_22_dec_2022( array $args, array $assoc_args ): void {
+        $start_time = microtime( true );
+
+        WP_CLI::line( 'Starting Orders and Customers Deletion' );
+
+        foreach ( $this->get_wc_orders( -1 ) as $order ) {
+            WP_CLI::line( sprintf( '[Memory: %s » Time: %s] Deleting Customer %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_customer_id() ) );
+            wp_delete_user( $order->get_customer_id() );
+
+            WP_CLI::line( sprintf( '[Memory: %s » Time: %s] Deleting order %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_id() ) );
+            wp_delete_post( $order->get_id() );
+        }
+
+        WP_CLI::success( 'All Orders and their Customers have been successfully deleted!' );
+    }
+
+    /**
+     * Get WooCommerce orders
+     */
+    private function get_wc_orders( $limit = 100 ): iterable {
+        $ids = wc_get_orders( [
+            'date_created' => '2022-12-22',
+            'status' => 'wc-failed',
+            'return' => 'ids',
+            'limit' => $limit,
+        ] );
+
+        foreach ( $ids as $id ) {
+            yield wc_get_order( $id );
+        }
+
+        return $ids;
+    }
+}

--- a/src/Command/PublisherSpecific/TheFifthEstateMigrator.php
+++ b/src/Command/PublisherSpecific/TheFifthEstateMigrator.php
@@ -58,7 +58,7 @@ class TheFifthEstateMigrator implements InterfaceCommand {
 
         WP_CLI::line( 'Starting Orders and Customers Deletion' );
 
-        foreach ( $this->get_wc_orders( -1 ) as $order ) {
+        foreach ( $this->get_wc_orders() as $order ) {
             WP_CLI::line( sprintf( '[Memory: %s » Time: %s] Deleting Customer %s', size_format( memory_get_usage( true ) ), human_time_diff( $start_time, microtime( true ) ), $order->get_customer_id() ) );
             wp_delete_user( $order->get_customer_id() );
 
@@ -72,12 +72,12 @@ class TheFifthEstateMigrator implements InterfaceCommand {
     /**
      * Get WooCommerce orders
      */
-    private function get_wc_orders( $limit = 100 ): iterable {
+    private function get_wc_orders(): iterable {
         $ids = wc_get_orders( [
             'date_created' => '2022-12-22',
             'status' => 'wc-failed',
             'return' => 'ids',
-            'limit' => $limit,
+            'limit' => -1,
         ] );
 
         foreach ( $ids as $id ) {


### PR DESCRIPTION
## Overview

This PR contains the migration for the Publisher "The Fifth Estate".

There is a command available to clean up all Orders from 22 Dec 2022. The command can be used like this:

```
wp newspack-content-migrator tfe-cleanup-orders-from-22dec2022
```

There is also a `dry-run` flag that won't proceed with the deletion.

```
wp newspack-content-migrator tfe-cleanup-orders-from-22dec2022 --dry-run
```

ℹ️ All of the logging is saved in a file with the name `tfe-cleanup-orders-from-22-dec-2022.log`

---

- [x] confirmed that PHPCS has been run
