### PR TITLE
Add support for blocks in inline featured image migrator

### DIFF
--- a/src/Command/General/InlineFeaturedImageMigrator.php
+++ b/src/Command/General/InlineFeaturedImageMigrator.php
@@ -229,7 +229,17 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 				$featured_image_used_in_post_content = false !== strpos( $post_content, $featured_image_no_host );
 				if ( ! $featured_image_used_in_post_content ) {
 					WP_CLI::line( sprintf( 'Featured image not used inline.', $post_id ) );
-					continue;
+				}
+
+				// Check if Featured Image is used anywhere in post_content blocks.
+				$image_blocks = $this->get_image_blocks_from_post_content_blocks( parse_blocks( $post_content ) );
+				foreach ( $image_blocks as $image_block ) {
+					if ( $image_block['attrs']['id'] == $thumbnail_id ) {
+						$this->logger->log( $log, sprintf( 'Post ID %d — Featured image used in image block.', $post_id ), $this->logger::SUCCESS );
+						$featured_image_used_in_post_content = true;
+
+						break;
+					}
 				}
 
 				// Hide featured image.


### PR DESCRIPTION
## Overview

This PR adds support for Gutenberg Blocks when checking if the Featured Image is used **anywhere** in post content.

The command for this is:

```
newspack-content-migrator hide-featured-image-if-used-in-post-content --anywhere-in-post-content
```

Currently, when the `--anywhere-in-post-content` flag is used, the command searches for a full match between the Featured Image src and the post content. However, when using Gutenberg Image Block, the image src in the post content can be a resized one which led to a mismatch and thus the command wasn't fully working.