### PR TITLE
Fix cmd_set_first_image_from_content_as_featured_image

### DIFF
--- a/src/Command/General/EmbarcaderoMigrator.php
+++ b/src/Command/General/EmbarcaderoMigrator.php
@@ -14,6 +14,7 @@ use NewspackCustomContentMigrator\Logic\CoAuthorPlus;
 use NewspackCustomContentMigrator\Logic\GutenbergBlockGenerator;
 use NewspackCustomContentMigrator\Logic\Taxonomy;
 use NewspackCustomContentMigrator\Utils\WordPressXMLHandler;
+use WP;
 use WP_CLI;
 
 /**
@@ -582,6 +583,34 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 						'type'        => 'assoc',
 						'name'        => 'story-photos-dir-path',
 						'description' => 'Path to the directory containing the stories\'s photos files to import.',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator embarcadero-list-posts-from-blog',
+			array( $this, 'cmd_embarcadero_list_posts_from_blog' ),
+			[
+				'shortdesc' => "Helper dev command. Lists post IDs imported from blog CSV. Does content validation and logs debugging info.",
+				'synopsis'  => [
+					[
+						'type'        => 'assoc',
+						'name'        => 'blogs-topics-csv-path',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'blogs-photos-csv-path',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'blogs-photos-dir-path',
 						'optional'    => false,
 						'repeating'   => false,
 					],
@@ -1637,6 +1666,92 @@ class EmbarcaderoMigrator implements InterfaceCommand {
 
 			$this->logger->log( self::TAGS_LOG_FILE, sprintf( 'Imported tags for post %d with the original ID %d: %s', $wp_post_id, $story_id, implode( ', ', $tags ) ), Logger::SUCCESS );
 		}
+	}
+	
+	/**
+	 * Callable for `newspack-content-migrator embarcadero-list-posts-from-blog`.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments.
+	 * @return void
+	 */
+	public function cmd_embarcadero_list_posts_from_blog( $args, $assoc_args ) {
+		global $wpdb;
+
+		$topics_csv_file_path  = $assoc_args['blogs-topics-csv-path'];
+		$photos_csv_file_path  = $assoc_args['blogs-photos-csv-path'];
+		$photos_dir            = $assoc_args['blogs-photos-dir-path'];
+
+		$topics = $this->get_data_from_csv_or_tsv( $topics_csv_file_path );
+		$photos = $this->get_data_from_csv_or_tsv( $photos_csv_file_path );
+
+		$post_ids_found = [];
+		$post_ids_not_same = [];
+		$topic_ids_not_found = [];
+		$debug_titles_not_same = [];
+
+		foreach ( $topics as $key_topic => $topic ) {
+			WP_CLI::line( sprintf( '(%d)/(%d) topic_id %d...', $key_topic + 1, count( $topics ), $topic['topic_id'] ) );
+
+			// Find post ID by postmeta original 'topic_id' (self::EMBARCADERO_ORIGINAL_TOPIC_ID_META_KEY is not used for blog stories on Palo Alto).
+			$meta_key = 'topic_id';
+			// Account for duplicates.
+			$post_ids = $wpdb->get_col( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = %s AND meta_value = %s", $meta_key, $topic['topic_id'] ) );
+			if ( ! $post_ids || empty( $post_ids ) ) {
+				WP_CLI::line( sprintf( 'WARNING not found post for topic_id %s', $topic['topic_id'] ) );
+				$topic_ids_not_found[] = $topic['topic_id'];
+				continue;
+			}
+
+			foreach ( $post_ids as $post_id ) {
+				// Validate post is the same as topic. Looks like this isn't needed, but just in case since this is retroactive.
+				$post = get_post( $post_id, ARRAY_A );
+				$blog_id = $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = %s AND post_id = %d", 'blog_id', $post_id ) );
+				$is_same_type = $post['post_type'] == 'post';
+				$is_same_title = $post['post_title'] == $topic["headline"];
+				if ( ! $is_same_title ) {
+					$encoded_title = str_replace( '"', '&quot;', $topic["headline"] );
+					$is_same_title = $post['post_title'] == $encoded_title;
+				}
+				if ( ! $is_same_title ) {
+					$is_same_title = $post['post_title'] == htmlspecialchars_decode( $topic["headline"] );
+				}
+				// Allow +-1 day for timezone differences.
+				$publish_plus1day = date("Y-m-d", strtotime($post['post_date'] . " +1 day"));
+				$publish_minus1day = date("Y-m-d", strtotime($post['post_date'] . " -1 day"));
+				$is_same_date = ( substr( $post['post_date'], 0, 10 ) == $topic["posted_date"] )
+					|| ( $publish_plus1day == $topic["posted_date"] )
+					|| ( $publish_minus1day == $topic["posted_date"] );
+				$is_same_blog = $blog_id == $topic["blog_id"];
+				if (
+					! $is_same_type ||
+					! $is_same_title ||
+					! $is_same_date || 
+					! $is_same_blog
+				) {
+					WP_CLI::line( sprintf( 'WARNING DEBUG post_id %d is not the same as topic_id %d (type:%s, title:%s, date:%s, blog:%s)', $post_id, $topic['topic_id'], (string) $is_same_type, (string) $is_same_title, (string) $is_same_date, (string) $is_same_blog ) );
+					$post_ids_not_same[] = $post_id;
+					if ( ! $is_same_title ) {
+						$debug_titles_not_same[] = [
+							$topic["headline"],
+							$post['post_title'],
+							'topic_id: ' . $topic['topic_id'], 
+							'post_id: ' . $post_id
+						];
+					}
+					continue;
+				}
+
+				WP_CLI::line( sprintf( 'FOUND post_id %d <= topic_id %d', $post_id, $topic['topic_id'] ) );
+				$post_ids_found[] = $post_id;
+			}
+		}
+
+		file_put_contents( 'cmd_found-post-ids.csv', implode( ",", $post_ids_found ) );
+		file_put_contents( 'cmd_post-ids-not-same.csv', implode( ",", $post_ids_not_same ) );
+		file_put_contents( 'cmd_topic-ids-not-found.csv', implode( ",", $topic_ids_not_found ) );
+		file_put_contents( 'cmd_debug_titles_not_same.json', json_encode( $debug_titles_not_same ) );
+		WP_CLI::line( 'Done, saved CSVs' );
 	}
 
 	/**

--- a/src/Command/General/InlineFeaturedImageMigrator.php
+++ b/src/Command/General/InlineFeaturedImageMigrator.php
@@ -395,12 +395,12 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 		}
 
 		foreach ( $post_ids as $k => $post_id ) {
-			WP_CLI::line( sprintf( '👉 (%d/%d) ID %d ...', $k + 1, count( $post_ids ), $post_id ) );
+			WP_CLI::line( sprintf( '(%d/%d) post ID %d ...', $k + 1, count( $post_ids ), $post_id ) );
 			
 			// Skip posts which already have a featured image.
 			if ( false == $re_set_existing_featured_images ) {
 				if ( get_post_thumbnail_id( $post_id ) ) {
-					WP_CLI::line( '× post already has a featured image, skipping.' );
+					WP_CLI::line( '× skipping, post already has a featured image.' );
 					continue;
 				}   
 			}   
@@ -416,14 +416,14 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 			$img_title = $img_data[0][1] ?? null;
 			$img_alt   = $img_data[0][2] ?? null;
 			if ( ! $img_src ) {
-				WP_CLI::line( '× no images found in Post.' );
+				WP_CLI::line( '× skipping, no images found in Post.' );
 				continue;
 			}
 
 			// Check if there's already an attachment with this image.
 			$is_src_fully_qualified = ( 0 == strpos( $img_src, 'http' ) );
 			if ( ! $is_src_fully_qualified ) {
-				WP_CLI::line( sprintf( '× skipping, img src `%s` not fully qualified URL', $img_src ) );
+				WP_CLI::line( sprintf( '× skipping, img src `%s` not fully qualified URL in post ID %s', $img_src, $post_id ) );
 				continue;
 			}
 
@@ -443,16 +443,16 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 			WP_CLI::line( sprintf( '- importing img `%s`...', $img_src ) );
 			$att_id = $this->attachments->import_external_file( $img_src, $img_title, $img_alt, $description = null, $img_alt, $post_id );
 			if ( is_wp_error( $att_id ) ) {
-				WP_CLI::warning( sprintf( '❗ ERROR importing img `%s` : %s', $img_src, $att_id->get_error_message() ) );
+				WP_CLI::warning( sprintf( '❗ ERROR importing img `%s` to post ID %s : %s', $img_src, $post_id, $att_id->get_error_message() ) );
 				continue;
 			}
 
 			// Set attachment as featured image.
 			$result_featured_set = set_post_thumbnail( $post_id, $att_id );
 			if ( ! $result_featured_set ) {
-				WP_CLI::warning( sprintf( '❗ could not set att.ID %s as featured image', $att_id ) );
+				WP_CLI::warning( sprintf( '❗ ERROR could not set att.ID %s as featured image to post ID %s', $att_id, $post_id ) );
 			} else {
-				WP_CLI::line( sprintf( '👍 set att.ID %s as featured image', $att_id ) );
+				WP_CLI::line( sprintf( '👍 SUCCESS att.ID %s set as featured image to post ID %s', $att_id, $post_id ) );
 			}
 		}
 

--- a/src/Command/General/InlineFeaturedImageMigrator.php
+++ b/src/Command/General/InlineFeaturedImageMigrator.php
@@ -397,9 +397,11 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 		foreach ( $post_ids as $k => $post_id ) {
 			WP_CLI::line( sprintf( '(%d/%d) post ID %d ...', $k + 1, count( $post_ids ), $post_id ) );
 			
+			$current_thumbnail_id = get_post_thumbnail_id( $post_id );
+			
 			// Skip posts which already have a featured image.
 			if ( false == $re_set_existing_featured_images ) {
-				if ( get_post_thumbnail_id( $post_id ) ) {
+				if ( $current_thumbnail_id ) {
 					WP_CLI::line( '× skipping, post already has a featured image.' );
 					continue;
 				}   
@@ -448,12 +450,18 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 			}
 
 			// Set attachment as featured image.
-			$result_featured_set = set_post_thumbnail( $post_id, $att_id );
-			if ( ! $result_featured_set ) {
-				WP_CLI::warning( sprintf( '❗ ERROR could not set att.ID %s as featured image to post ID %s', $att_id, $post_id ) );
+			if ( $current_thumbnail_id == $att_id ) {
+				WP_CLI::line( sprintf( '× skipping, att.ID %s is already correct on post ID %s', $att_id, $post_id ) );
+				continue;
 			} else {
-				WP_CLI::line( sprintf( '👍 SUCCESS att.ID %s set as featured image to post ID %s', $att_id, $post_id ) );
+				$result_featured_set = set_post_thumbnail( $post_id, $att_id );
+				if ( ! $result_featured_set ) {
+					WP_CLI::warning( sprintf( '❗ ERROR could not set att.ID %s as featured image to post ID %s', $att_id, $post_id ) );
+				} else {
+					WP_CLI::line( sprintf( '👍 SUCCESS att.ID %s set as featured image to post ID %s', $att_id, $post_id ) );
+				}
 			}
+
 		}
 
 		WP_CLI::line( 'All done! 🙌' );


### PR DESCRIPTION
## Reusable code for review
### Fixes made to `cmd_set_first_image_from_content_as_featured_image`
- there is no need for the logic which separately works on blocks. The existing fetching of `<img src>` works well both on blocks and HTML
- removed this whole block, because the `$this->attachments->import_external_file` has a more advanced inner function where it will fetch existing attachment if it already exist -- [check this](https://github.com/Automattic/newspack-custom-content-migrator/blob/trunk/src/Logic/Attachments.php#L112). Also aways use `$this->attachments->import_external_file` when importing images in migration scripts since that's our team's standard
```
// Import attachment if it doesn't exist.
$att_id = 
    $attachment = get_post( $att_id );
    if ( $attachment ) {
        ...
```
- Updated comment to clarify what code was doing
```
fom: // The code below strips the CDN _pattern_ to leave the _original URL_ which can be both
to: // The code below strips the CDN **hostname and query parameters** and leaves the **local hostname without query params** which can be fetched both
```
- for the bit where query params are removed, I'd recommend using `parse_url` as it's are more readable (OK to leave this now 👍 )
- Added skip trying to set featured image if the current one is already correct

### Small updates to `cmd_set_first_image_from_content_as_featured_image`
- added optional argument to only process specific post IDs
- added optional argument to run on all posts, even those which already have a featured image
- initializing common logic objects in constructor, not in command
- I updated the logs to be more readable and **searchable**

## Publisher specific code
- ...

---

- [x] confirmed that PHPCS has been run
