### PR TITLE
Fix / Simply Guest Author Name Plugin loop

### DIFF
--- a/src/Command/General/SimplyGuestAuthorNameMigrator.php
+++ b/src/Command/General/SimplyGuestAuthorNameMigrator.php
@@ -115,7 +115,9 @@ class SimplyGuestAuthorNameMigrator implements InterfaceCommand {
 
 		$overwrite_post_gas = ( isset( $assoc_args['overwrite-post-gas'] ) ) ? true : false;
 
-		if( $overwrite_post_gas ) $this->logger->log( $log, 'With --overwrite-post-gas.' );
+		if ( $overwrite_post_gas ) {
+			$this->logger->log( $log, 'With --overwrite-post-gas.' );
+		}
 
 		// Must have required postmeta value.
 		$meta_query = array(
@@ -184,14 +186,13 @@ class SimplyGuestAuthorNameMigrator implements InterfaceCommand {
 				// Assign to post.
 
 				$existing_post_gas = $this->coauthorsplus_logic->get_guest_authors_for_post( $post_id );
-				$this->logger->log( $log, 'Existing post GAs count:' . count( $existing_post_gas) );
+				$this->logger->log( $log, 'Existing post GAs count:' . count( $existing_post_gas ) );
 
 				// If no GAs exist on post, or "overwrite" is true, then set gas to post. 
-				if( 0 == count( $existing_post_gas) || $overwrite_post_gas ) {
+				if ( 0 == count( $existing_post_gas ) || $overwrite_post_gas ) {
 					$this->coauthorsplus_logic->assign_guest_authors_to_post( array( $ga->ID ), $post_id );
 					$this->logger->log( $log, 'Assigned GAs to post.' );
-				}
-				else {
+				} else {
 					$this->logger->log( $log, 'Post GAs unchanged.' );
 				}
 

--- a/src/Command/General/SimplyGuestAuthorNameMigrator.php
+++ b/src/Command/General/SimplyGuestAuthorNameMigrator.php
@@ -113,6 +113,10 @@ class SimplyGuestAuthorNameMigrator implements InterfaceCommand {
 
 		$this->logger->log( $log, 'Starting migration.' );
 
+		$overwrite_post_gas = ( isset( $assoc_args['overwrite-post-gas'] ) ) ? true : false;
+
+		if( $overwrite_post_gas ) $this->logger->log( $log, 'With --overwrite-post-gas.' );
+
 		// Must have required postmeta value.
 		$meta_query = array(
 			array(
@@ -122,31 +126,17 @@ class SimplyGuestAuthorNameMigrator implements InterfaceCommand {
 			),
 		);              
 
-		// Optional overwrite existing GAs on posts.
-		if ( isset( $assoc_args['overwrite-post-gas'] ) ) {
-			$tax_query = null;
-		} else {
-			// Default: only process posts where GA does not exist.
-			$tax_query = array(
-				array(
-					'taxonomy' => 'author',
-					'operator' => 'NOT EXISTS', 
-				),
-			);  
-		}
-
 		$this->posts_logic->throttled_posts_loop(
 			array(
 				'post_type'   => 'post',
 				'post_status' => array( 'publish' ),
 				'fields'      => 'ids',
 				'meta_query'  => $meta_query,
-				'tax_query'   => $tax_query,
 				// Order by date desc so newest GAs will have newest Bios.
 				'orderby'     => 'date',
 				'order'       => 'DESC',
 			),
-			function ( $post_id ) use ( $log ) {
+			function ( $post_id ) use ( $log, $overwrite_post_gas ) {
 
 				$this->logger->log( $log, 'Post id: ' . $post_id );
 
@@ -192,10 +182,22 @@ class SimplyGuestAuthorNameMigrator implements InterfaceCommand {
 				$this->logger->log( $log, 'GA ID: ' . $ga->ID );
 
 				// Assign to post.
-				$this->coauthorsplus_logic->assign_guest_authors_to_post( array( $ga->ID ), $post_id );
+
+				$existing_post_gas = $this->coauthorsplus_logic->get_guest_authors_for_post( $post_id );
+				$this->logger->log( $log, 'Existing post GAs count:' . count( $existing_post_gas) );
+
+				// If no GAs exist on post, or "overwrite" is true, then set gas to post. 
+				if( 0 == count( $existing_post_gas) || $overwrite_post_gas ) {
+					$this->coauthorsplus_logic->assign_guest_authors_to_post( array( $ga->ID ), $post_id );
+					$this->logger->log( $log, 'Assigned GAs to post.' );
+				}
+				else {
+					$this->logger->log( $log, 'Post GAs unchanged.' );
+				}
 
 				// Skip Bio creation if already set.
 				if ( ! empty( trim( $ga->description ) ) ) {
+					$this->logger->log( $log, 'GA bio exists.' );
 					return;
 				}
 				
@@ -213,6 +215,7 @@ class SimplyGuestAuthorNameMigrator implements InterfaceCommand {
 				}
 
 				if ( empty( $new_desc ) ) {
+					$this->logger->log( $log, 'No new bio info.' );
 					return;
 				}
 				


### PR DESCRIPTION
Fixed previous [PR](https://github.com/Automattic/newspack-custom-content-migrator/pull/459) so that the loop will cycle through all posts that contain the postmeta value.  The previous PR had a `tax_query` that did not work well with the `throttled_posts_loop` function.  There is no change to the usage.  This new code just fixes a bug that hadn't been seen yet.  
 
---
- [x] confirmed that PHPCS has been run
