### PR TITLE
Add / Hide All Featured Images

### DIFF
--- a/src/Command/General/InlineFeaturedImageMigrator.php
+++ b/src/Command/General/InlineFeaturedImageMigrator.php
@@ -129,6 +129,14 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 				],
 			]
 		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator hide-all-featured-images',
+			[ $this, 'cmd_hide_all_featured_images' ],
+			[
+				'shortdesc' => 'Hide ALL featured image.',
+			]
+		);
 	}
 
 	/**
@@ -553,6 +561,54 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 		}
 
 		WP_CLI::line( sprintf( 'Finished. See %s/ folder for logs.', $log_dir ) );
+	}
+
+	/**
+	 * Callable for `newspack-content-migrator hide-all-featured-images`.
+	 *
+	 * @param array $positional_args Positional arguments.
+	 * @param array $assoc_args      Associative arguments.
+	 * @return void
+	 */
+	public function cmd_hide_all_featured_images( $positional_args, $assoc_args ) {
+		
+		$log_file = 'hide_all_featured_images.log';
+
+		$this->logger->log( $log_file, 'Starting hide ALL featured images.' );
+
+		// Posts with a featured image.
+		$query_args = [
+			'post_type'   => 'post',
+			'post_status' => 'any',
+			'fields'      => 'ids',
+			'meta_query'  => [
+				[
+					'key'     => '_thumbnail_id',
+					'value'   => '',
+					'compare' => '!=',
+				],
+			],
+		];
+
+		$counter = 0;
+
+		$this->post_logic->throttled_posts_loop(
+			$query_args, 
+			function ( $post_id ) use( $log_file, &$counter ) {
+
+				update_post_meta( $post_id, 'newspack_featured_image_position', 'hidden' );
+
+				$this->logger->log( $log_file, sprintf( 'Featured image hidden for the post %d', $post_id ) );
+
+				$counter++;
+			}
+		);
+
+		$this->logger->log( $log_file, 'Updated count: ' . $counter );
+		
+		wp_cache_flush();
+
+		$this->logger->log( $log_file, 'Done', $this->logger::SUCCESS );
 	}
 
 	/**

--- a/src/Command/General/PostsMigrator.php
+++ b/src/Command/General/PostsMigrator.php
@@ -287,14 +287,6 @@ class PostsMigrator implements InterfaceCommand {
 				],
 			]
 		);
-
-		WP_CLI::add_command(
-			'newspack-content-migrator hide-all-featured-images',
-			[ $this, 'cmd_hide_all_featured_images' ],
-			[
-				'shortdesc' => 'Hide ALL featured image.',
-			]
-		);
 	}
 
 	/**
@@ -799,54 +791,6 @@ class PostsMigrator implements InterfaceCommand {
 		}
 
 		wp_cache_flush();
-	}
-
-	/**
-	 * Callable for `newspack-content-migrator hide-all-featured-images`.
-	 *
-	 * @param array $positional_args Positional arguments.
-	 * @param array $assoc_args      Associative arguments.
-	 * @return void
-	 */
-	public function cmd_hide_all_featured_images( $positional_args, $assoc_args ) {
-		
-		$log_file = 'hide_all_featured_images.log';
-
-		$this->logger->log( $log_file, 'Starting hide ALL featured images.' );
-
-		// Posts with a featured image.
-		$query_args = [
-			'post_type'   => 'post',
-			'post_status' => 'any',
-			'fields'      => 'ids',
-			'meta_query'  => [
-				[
-					'key'     => '_thumbnail_id',
-					'value'   => '',
-					'compare' => '!=',
-				],
-			],
-		];
-
-		$counter = 0;
-
-		$this->posts_logic->throttled_posts_loop(
-			$query_args, 
-			function ( $post_id ) use( $log_file, &$counter ) {
-
-				update_post_meta( $post_id, 'newspack_featured_image_position', 'hidden' );
-
-				$this->logger->log( $log_file, sprintf( 'Featured image hidden for the post %d', $post_id ) );
-
-				$counter++;
-			}
-		);
-
-		$this->logger->log( $log_file, 'Updated count: ' . $counter );
-		
-		wp_cache_flush();
-
-		$this->logger->log( $log_file, 'Done', $this->logger::SUCCESS );
 	}
 
 	/**

--- a/src/Command/General/PostsMigrator.php
+++ b/src/Command/General/PostsMigrator.php
@@ -287,6 +287,14 @@ class PostsMigrator implements InterfaceCommand {
 				],
 			]
 		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator hide-all-featured-images',
+			[ $this, 'cmd_hide_all_featured_images' ],
+			[
+				'shortdesc' => 'Hide ALL featured image.',
+			]
+		);
 	}
 
 	/**
@@ -789,6 +797,41 @@ class PostsMigrator implements InterfaceCommand {
 				true
 			);
 		}
+
+		wp_cache_flush();
+	}
+
+	/**
+	 * Callable for `newspack-content-migrator hide-all-featured-images`.
+	 *
+	 * @param array $positional_args Positional arguments.
+	 * @param array $assoc_args      Associative arguments.
+	 * @return void
+	 */
+	public function cmd_hide_all_featured_images( $positional_args, $assoc_args ) {
+		
+		$log_file = 'hide_all_featured_images.log';
+
+		$this->logger->log( $log_file, 'Starting hide ALL featured images.' );
+
+		$query_args = [
+			'post_type'   => 'post',
+			'post_status' => 'any',
+			'fields'      => 'ids',
+		];
+
+		$this->posts_logic->throttled_posts_loop(
+			$query_args, 
+			function ( $post_id ) use( $log_file ) {
+
+				// update_post_meta( $post_id, 'newspack_featured_image_position', 'hidden' );
+
+				$this->logger->log(
+					$log_file,
+					sprintf( 'Featured image hidden for the post %d', $post_id )
+				);
+			}
+		);
 
 		wp_cache_flush();
 	}

--- a/src/Command/General/PostsMigrator.php
+++ b/src/Command/General/PostsMigrator.php
@@ -814,26 +814,39 @@ class PostsMigrator implements InterfaceCommand {
 
 		$this->logger->log( $log_file, 'Starting hide ALL featured images.' );
 
+		// Posts with a featured image.
 		$query_args = [
 			'post_type'   => 'post',
 			'post_status' => 'any',
 			'fields'      => 'ids',
+			'meta_query'  => [
+				[
+					'key'     => '_thumbnail_id',
+					'value'   => '',
+					'compare' => '!=',
+				],
+			],
 		];
+
+		$counter = 0;
 
 		$this->posts_logic->throttled_posts_loop(
 			$query_args, 
-			function ( $post_id ) use( $log_file ) {
+			function ( $post_id ) use( $log_file, &$counter ) {
 
-				// update_post_meta( $post_id, 'newspack_featured_image_position', 'hidden' );
+				update_post_meta( $post_id, 'newspack_featured_image_position', 'hidden' );
 
-				$this->logger->log(
-					$log_file,
-					sprintf( 'Featured image hidden for the post %d', $post_id )
-				);
+				$this->logger->log( $log_file, sprintf( 'Featured image hidden for the post %d', $post_id ) );
+
+				$counter++;
 			}
 		);
 
+		$this->logger->log( $log_file, 'Updated count: ' . $counter );
+		
 		wp_cache_flush();
+
+		$this->logger->log( $log_file, 'Done', $this->logger::SUCCESS );
 	}
 
 	/**


### PR DESCRIPTION
This general use CLI will add postmeta `newspack_featured_image_position = 'hidden'` to all posts that have a featured image.

Usage: `wp newspack-content-migrator hide-all-featured-images`

Output log: `hide_all_featured_images.log`

Note:
- There is a similar existing command (`newspack-content-migrator hide-featured-images`) in file (`src/Command/General/PostsMigrator.php`).  After reviewing that command it would have been more work to refactor it for this new use case.  The existing command requires a list of post ids and/or a category id.  Our use case doesn't call for a list of post ids nor category id.  Additionally the existing command needs to be called multiple times in order to process all rows (or use a very high `posts-per-batch` count that could take up too much processing power).  The new command in this PR makes use of `throttled_posts_loop` to by pass this concern.

---

- [x] **(only for this new code)** confirmed that PHPCS has been run
