### PR TITLE
East Mojo: Add broken images cleanup command

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -90,5 +90,6 @@ PluginSetup::register_migrators(
 		Command\PublisherSpecific\BigBendSentinelMigrator::class,
 		Command\PublisherSpecific\LAFocusMigrator::class,
 		Command\PublisherSpecific\TheFifthEstateMigrator::class,
+		Command\PublisherSpecific\EastMojoMigrator::class,
 	)
 );


### PR DESCRIPTION
## Overview

This PR adds a new command that removes images in posts' content with hostname - `gumlet.assettype.com`.

In order to run the command, you can use the following call:

```
wp newspack-content-migrator eastmojo-cleanup-broken-images-in-post-content
```

⚠️ The command takes care of plain `img` tags, as well as `img` tags in a `figure` tag

---

- [x] confirmed that PHPCS has been run
