### PR TITLE
Add support for image blocks

### DIFF
--- a/src/Command/General/InlineFeaturedImageMigrator.php
+++ b/src/Command/General/InlineFeaturedImageMigrator.php
@@ -418,7 +418,7 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 			// Get content for crawling.
 			$post_content = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE ID = %d", $post_id ) );
 
-			$image_blocks = $this->get_image_blocks_from_post_content_blocks( parse_blocks( $post_content ) );
+			$image_blocks                       = $this->get_image_blocks_from_post_content_blocks( parse_blocks( $post_content ) );
 			$has_set_featured_image_from_blocks = false;
 
 			if ( ! empty( $image_blocks ) ) {
@@ -445,7 +445,7 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 			// Reaching here means that either of the following is true:
 			// 1. There aren't image blocks.
 			// 2. There are image blocks, however, we couldn't use them to set the Thumbnail because
-			//    the referenced image in the image block is not actually an uploaded Attachment.
+			// the referenced image in the image block is not actually an uploaded Attachment.
 
 			// Find the first <img>.
 			$this->crawler->clear();
@@ -497,8 +497,7 @@ class InlineFeaturedImageMigrator implements InterfaceCommand {
 				} else {
 					WP_CLI::line( sprintf( '👍 SUCCESS att.ID %s set as featured image to post ID %s', $att_id, $post_id ) );
 				}
-			}
-
+			}       
 		}
 
 		WP_CLI::line( 'All done! 🙌' );


### PR DESCRIPTION
## Overview

This PR is a continuation of https://github.com/Automattic/newspack-custom-content-migrator/pull/475.

It adds the removed support for image blocks parsing.

The logic is to loop through each image block of a Post and test if it can be used as a Featured Image. If such blocks don't exist or the images inside are not an actual Attachment, continue with the raw post content parsing.

---

- [x] confirmed that PHPCS has been run
