### PR TITLE
Add a very basic time machine for posts

### DIFF
--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -74,6 +74,7 @@ PluginSetup::register_migrators(
 		Command\General\PostDateMigrator::class,
 		Command\General\SimplyGuestAuthorNameMigrator::class,
 		Command\General\TagDivThemesPluginsMigrator::class,
+		Command\General\PostTimeMachineCommand::class,
 
 		// Publisher specific, remove when launched.
 		Command\PublisherSpecific\SoccerAmericaMigrator::class,

--- a/src/Command/General/PostTimeMachineCommand.php
+++ b/src/Command/General/PostTimeMachineCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Command\General;
+
+use Exception;
+use NewspackCustomContentMigrator\Command\InterfaceCommand;
+use NewspackCustomContentMigrator\Utils\PostTimeMachine;
+use WP_CLI;
+
+class PostTimeMachineCommand implements InterfaceCommand {
+
+	private function __construct() {
+		// Nothing here.
+	}
+
+	/**
+	 * Singleton.
+	 *
+	 * @return self
+	 */
+	public static function get_instance(): self {
+		static $instance;
+		if ( null === $instance ) {
+			$instance = new self();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register_commands() {
+		WP_CLI::add_command(
+			'newspack-content-migrator post-time-machine-restore-snapshot',
+			[ $this, 'cmd_post_time_machine_restore_snapshot' ],
+			[
+				'shortdesc' => 'Restore posts from a snapshot CSV file.',
+				'synopsis'  => [
+					[
+						'type'        => 'positional',
+						'name'        => 'snapshot-csv',
+						'description' => 'The CSV file to restore posts from.',
+						'optional'    => false,
+					],
+				],
+			]
+		);
+
+		WP_CLI::add_command(
+			'newspack-content-migrator post-time-machine-test',
+			[ $this, 'cmd_post_time_machine_test' ]
+		);
+	}
+
+	/**
+	 * This is just for testing and can be removed at some point. It WILL mess with content, so be careful.
+	 *
+	 * @param array $pos_args Pos args.
+	 * @param array $assoc_args Assoc args.
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function cmd_post_time_machine_test( array $pos_args, array $assoc_args ): void {
+		$snapshot_file = PostTimeMachine::get_dated_snapshot_file_name();
+
+		global $wpdb;
+		$posts = $wpdb->get_results(
+			"SELECT ID, post_content FROM $wpdb->posts WHERE post_content LIKE '% the %' AND post_type = 'post' AND post_status = 'publish' ORDER BY RAND() LIMIT 3"
+		);
+
+		foreach ( $posts as $post ) {
+			$content = str_replace( ' the ', ' tha ', $post->post_content );
+			// Do this before updating the post.
+			PostTimeMachine::snapshot_post( $snapshot_file, $post->ID );
+
+			wp_update_post( [ 'ID' => $post->ID, 'post_content' => $content ] );
+			WP_CLI::log( 'Updated post ' . $post->ID );
+		}
+		WP_CLI::log( sprintf( "Snapshot file:\n %s\n%s", $snapshot_file, file_get_contents( $snapshot_file ) ) );
+	}
+
+
+	/**
+	 * Restore all posts to the version in the snapshot file.
+	 *
+	 * @param array $pos_args Pos args.
+	 * @param array $assoc_args Assoc args.
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function cmd_post_time_machine_restore_snapshot( array $pos_args, array $assoc_args ): void {
+		$snapshot_file = $pos_args[0];
+		PostTimeMachine::restore_snapshot( $snapshot_file );
+	}
+}

--- a/src/Utils/PostTimeMachine.php
+++ b/src/Utils/PostTimeMachine.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace NewspackCustomContentMigrator\Utils;
+
+use Exception;
+use WP_CLI;
+
+class PostTimeMachine {
+
+	/**
+	 * Helper function to get the latest version ID of a post.
+	 *
+	 * @param int $post_id
+	 *
+	 * @return int
+	 */
+	private static function get_current_version_id( int $post_id ): int {
+		$revision_data = wp_get_latest_revision_id_and_total_count( $post_id );
+		if ( empty( $revision_data['latest_id'] ) ) {
+			return $post_id;
+		}
+
+		return $revision_data['latest_id'];
+	}
+
+	/**
+	 * Saves the version ID of a post to a snapshot file.
+	 *
+	 * @param string $snapshot_file_name The name of the snapshot file.
+	 * @param int    $post_id The id of the post.
+	 * @param int    $version_id The version id of the version of the post.
+	 *
+	 * @return void
+	 * @throws Exception If there is an error opening the file.
+	 *
+	 */
+	public static function snapshot_post_version( string $snapshot_file_name, int $post_id, int $version_id ): void {
+		// Open the file for appending
+		$csv_resource = fopen( $snapshot_file_name, 'a' );
+
+		if ( $csv_resource === false ) {
+			throw new Exception( "PostTimeMachine: Unable to open file: $snapshot_file_name" );
+		}
+
+		// Do some things only once.
+		static $header_written, $revision_url_placeholder, $edit_url_placeholder = null;
+		if ( empty( $header_written[ $snapshot_file_name ] ) ) {
+			// Write headers.
+			fputcsv( $csv_resource, [ 'ID', 'version_id', 'action_url' ] );
+			$header_written[ $snapshot_file_name ] = true;
+
+			// Get some url placeholders ready.
+			$revision_url_placeholder = admin_url( 'revision.php?revision=%s' );
+			$edit_url_placeholder     = admin_url( 'post.php?post=%s&action=edit' );
+		}
+
+		$url_placeholder = ( $post_id === $version_id ) ? $edit_url_placeholder : $revision_url_placeholder;
+
+		fputcsv(
+			$csv_resource,
+			[
+				$post_id,
+				$version_id,
+				sprintf( $url_placeholder, $version_id )
+			]
+		);
+		fclose( $csv_resource );
+	}
+
+	/**
+	 * Write a post to the snapshot file.
+	 *
+	 * @param string $snapshot_file_name File name of the snapshot file.
+	 * @param int    $post_id ID of the post to snapshot.
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public static function snapshot_post( string $snapshot_file_name, int $post_id ): void {
+		$version_id = self::get_current_version_id( $post_id );
+
+		self::snapshot_post_version( $snapshot_file_name, $post_id, $version_id );
+	}
+
+
+	/**
+	 * Restore all files in a snapshot file to the versions specified in the file.
+	 *
+	 * @param string $snapshot_file_name
+	 *
+	 * @return void
+	 * @throws Exception If anything goes wrong.
+	 */
+	public static function restore_snapshot( string $snapshot_file_name ): void {
+		// TODO. add a param to bail on restore if there are revisions between the current and the one in the snapshot.
+		$csv_iterator = new CsvIterator();
+		foreach ( $csv_iterator->items( $snapshot_file_name, ',' ) as $item ) {
+			if ( $item['version_id'] === $item['ID'] ) {
+				$revision = array_key_last( wp_get_post_revisions( $item['ID'] ) );
+			} else {
+				$revision = $item['version_id'];
+			}
+			if ( wp_restore_post_revision( $revision ) ) {
+				WP_CLI::success( sprintf( 'Restored post %d to revision %d: %s', $item['ID'], $revision, get_permalink( $item['ID'] ) ) );
+			}
+		}
+	}
+
+	/**
+	 * Helper to get a consistent file name for dated snapshots.
+	 *
+	 * @return string A csv file name with the command name and a date.
+	 */
+	public static function get_dated_snapshot_file_name(): string {
+		global $argv;
+		$command = 'timemachine-' . $argv[2] ?? 'some-command';
+
+		return sprintf( '%s-%s.csv', $command, date( 'Y-m-d-H-i-s' ) );
+	}
+
+}


### PR DESCRIPTION
This is a very first and naive stab at a "Time Machine" we can use to record revisions of a post and roll back to that revision if we need to.

The idea is that we update a .csv file with revision ids when we run a command, and should we need to roll content back, we can with this thingy.

There are two files:

* The `PostTimeMachine` that you would call from your migration command to record a "snapshot" of a post that you are about to do something to.
* The `PostTimeMachineCommand` that just has a command to restore revisions from a snapshot file.

A snapshot file is simply a csv file for now. It could look something like this:

```
ID,version_id,revision_url
41046,41950,https://some-site.local/wp-admin/revision.php?revision=41950
41047,41948,https://some-site.local/wp-admin/revision.php?revision=41948
9541,9541,https://some-site.local/wp-admin/post.php?post=9541&action=edit
```

The url is clickable and can maybe be of help with debugging. Note that it takes you to the revision snapshotted, but to compare with the latest you have to either click "Next" or "Compare any two revisions" to see the diff. I wish WP supported a url like https://some-site.local/wp-admin/revision.php?from=67180&to=current but it looks like no. Also note that the last one is an edit url. If a post has no existing revisions, this revisions url will not work. We could work around that with wrapping `wp_update_post` someday and then grab before and after.

## How to test

Take a look at the command ` wp newspack-content-migrator post-time-machine-test` (`cmd_post_time_machine_test()`). That is probably the best way to grok what is going on. That command we can remove later, but while we play around with this it's handy.

---

- [ ] confirmed that PHPCS has been run
