### PR TITLE
feat(CCMMigrator): brands migration commands

### DIFF
--- a/src/Command/PublisherSpecific/CCMMigrator.php
+++ b/src/Command/PublisherSpecific/CCMMigrator.php
@@ -938,16 +938,17 @@ class CCMMigrator implements InterfaceCommand {
 
 		foreach ( $posts as $post ) {
 			// Get brands from meta.
-			$brands    = get_post_meta( $post->ID, '_newspack_post_brands', true );
-			$brand_ids = array_map(
-				function ( $brand ) {
-					$term = get_term_by( 'name', $brand, 'brand' );
-					return $term ? $term->term_id : null;
-				},
-				$brands
-			);
+			$brands = get_post_meta( $post->ID, '_newspack_post_brands', true );
 
 			if ( $brands ) {
+				$brand_ids = array_map(
+					function ( $brand ) {
+						$term = get_term_by( 'name', $brand, 'brand' );
+						return $term ? $term->term_id : null;
+					},
+					$brands
+				);
+
 				// Set post brands.
 				wp_set_post_terms( $post->ID, $brand_ids, 'brand' );
 

--- a/src/Command/PublisherSpecific/CCMMigrator.php
+++ b/src/Command/PublisherSpecific/CCMMigrator.php
@@ -2,14 +2,14 @@
 
 namespace NewspackCustomContentMigrator\Command\PublisherSpecific;
 
-use \WP_CLI;
-use \NewspackCustomContentMigrator\Command\InterfaceCommand;
+use WP_CLI;
+use NewspackCustomContentMigrator\Command\InterfaceCommand;
 use NewspackCustomContentMigrator\Logic\CoAuthorPlus as CoAuthorPlusLogic;
-use \NewspackContentConverter\ContentPatcher\ElementManipulators\SquareBracketsElementManipulator;
-use \NewspackCustomContentMigrator\Logic\GutenbergBlockGenerator;
-use \NewspackCustomContentMigrator\Logic\Attachments as AttachmentsLogic;
-use \NewspackCustomContentMigrator\Utils\Logger;
-use \NewspackCustomContentMigrator\Logic\Taxonomy;
+use NewspackContentConverter\ContentPatcher\ElementManipulators\SquareBracketsElementManipulator;
+use NewspackCustomContentMigrator\Logic\GutenbergBlockGenerator;
+use NewspackCustomContentMigrator\Logic\Attachments as AttachmentsLogic;
+use NewspackCustomContentMigrator\Utils\Logger;
+use NewspackCustomContentMigrator\Logic\Taxonomy;
 
 /**
  * Custom migration scripts for Saporta News.
@@ -680,7 +680,7 @@ class CCMMigrator implements InterfaceCommand {
 
 			$cleaned_co_authors = array_filter(
 				array_map(
-					function( $co_author ) {
+					function ( $co_author ) {
 						$co_author = trim( $co_author );
 						// Remove "By By:" prefix.
 						$co_author = preg_replace( '/^By By:\s*/', '', $co_author );


### PR DESCRIPTION
This PR adds two commands to migrate brands to a temporary post meta and then migrate them back as brands.

- [x] confirmed that PHPCS has been run
