### PR TITLE
Medium Migrator: Change Inline Images Handler

### DIFF
--- a/src/Command/General/MediumMigrator.php
+++ b/src/Command/General/MediumMigrator.php
@@ -261,17 +261,18 @@ class MediumMigrator implements InterfaceCommand {
 			// Download or import the image file.
 			WP_CLI::line( sprintf( '✓ importing %s ...', $src ) );
 			$attachment_id = $this->attachments->import_external_file( $src, $title, $caption, null, $alt, $post_id );
-
-			// Replace the URI in Post content with the new one.
-			$img_uri_new          = wp_get_attachment_url( $attachment_id );
-
+			
 			if ( $figure->count() > 0 ) {
+				$image_block = $this->block_generator->get_image( get_post( $attachment_id ), 'full', false );
+
 				$post_content_updated = str_replace(
 					$figure->outerHtml(),
-					serialize_blocks( [ $this->block_generator->get_image( get_post( $attachment_id ), 'full', false ) ] ),
+					serialize_block( $image_block ),
 					$post_content_updated
 				);
 			} else {
+				// Replace the URI in Post content with the new one.
+				$img_uri_new          = wp_get_attachment_url( $attachment_id );
 				$post_content_updated = str_replace( array( esc_attr( $src ), $src ), $img_uri_new, $post_content_updated );
 			}
 		});

--- a/src/Command/General/MediumMigrator.php
+++ b/src/Command/General/MediumMigrator.php
@@ -115,13 +115,6 @@ class MediumMigrator implements InterfaceCommand {
 						'optional'    => true,
 						'repeating'   => false,
 					],
-					[
-						'type'        => 'flag',
-						'name'        => 'ignore-broken-images',
-						'description' => 'Only pass this flag if you are OK with getting images imported wrong.',
-						'optional'    => true,
-						'repeating'   => false,
-					],
 				],
 			]
 		);
@@ -137,10 +130,6 @@ class MediumMigrator implements InterfaceCommand {
 		if ( ! $this->simple_local_avatars_logic->is_sla_plugin_active() ) {
 			WP_CLI::error( 'Simple Local Avatars not found. Install and activate it before using this command.' );
 		}
-
-		// if ( ! WP_CLI\Utils\get_flag_value($assoc_args, 'ignore-broken-images', false ) ) {
-		// 	WP_CLI::error( 'You must pass the --ignore-broken-images flag to use this command. Ideally the image importer should be fixed before running. See TODO comment in import_post_images().' );
-		// }
 
 		$articles_csv_file_path = $assoc_args['zip-archive'];
 		$refresh_content        = isset( $assoc_args['refresh-content'] ) ? true : false;


### PR DESCRIPTION
## Description

Medium uses `data-width` and `data-height` attributes for images in articles. These dimensions don't make sense in the context of uploading the images in WordPress. The Medium Migrator command was importing the images into the Media Library but was leaving the incorrect dimensions in the post content.

In addition, the caption related to the image was not updated on the uploaded Attachment.

To fix both issues the Migrator has been updated to:

 * parse the related image caption and use it as a caption for the Attachment
 * replace the whole image with a Gutenberg Image Block

## How to test

You will need a Medium Export Archive to run the migration locally. Ping me and I can send a sample to you 😊

---

- [x] confirmed that PHPCS has been run
