### PR TITLE
fix: type casting `$attachment_id` to `int`. Now matches DocBlock.

### DIFF
--- a/src/Logic/Attachments.php
+++ b/src/Logic/Attachments.php
@@ -211,7 +211,7 @@ class Attachments {
 			}
 
 			if ( md5_file( $candidate_path ) === md5_file( $filepath ) ) {
-				return $attachment_id;
+				return intval( $attachment_id );
 			}
 		}
 


### PR DESCRIPTION
Although `$attachment_id` is an integer value, it technically remains a string because that's how it's returned from the `$wpdb` query result. To match the DocBlock description of the return values, a call to `intval` has been added to ensure that the `$attachment_id` being return is indeed an integer.
---

- [X] confirmed that PHPCS has been run
