### PR TITLE
Func was returning ID for recently inserted `wp_usermeta` row, not `wp_users` ID as intended.

### DIFF
--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -2758,7 +2758,7 @@ class ContentDiffMigrator {
 			]
 		);
 
-		return $this->wpdb->insert_id;
+		return $new_user_id;
 	}
 
 	/**


### PR DESCRIPTION
I ran this on a staging site and confirmed that the missing authors were properly created after a recent jetpack content refresh found them to be missing.
---

- [X] confirmed that PHPCS has been run
