### PR TITLE
Add tweaks for drupal migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,8 @@
     ]
   },
   "scripts": {
+    "phpcs": "./vendor/bin/phpcs",
+    "phpcbf": "./vendor/bin/phpcbf",
     "release": [
       "composer install --no-dev --optimize-autoloader",
       "composer archive --format=zip --dir=release --file=newspack-custom-content-migrator"

--- a/src/Command/PublisherSpecific/CarsonNowMigrator.php
+++ b/src/Command/PublisherSpecific/CarsonNowMigrator.php
@@ -342,6 +342,8 @@ class CarsonNowMigrator implements InterfaceCommand {
 			WP_CLI::error( 'Could not get database connection details from environment variables.' );
 		}
 
+		$options['prefix'] = $this->get_prefix();
+
 		return $options;
 	}
 
@@ -399,13 +401,18 @@ class CarsonNowMigrator implements InterfaceCommand {
 		];
 	}
 
+
+	/**
+	 * Get the prefix for the drupal tables.
+	 *
+	 * @return string
+	 */
 	private function get_prefix(): string {
 		if ( defined( 'NCCM_DRUPAL_PREFIX' ) || ! empty( trim( NCCM_DRUPAL_PREFIX ) ) ) {
 			return NCCM_DRUPAL_PREFIX;
 		}
-		global $table_prefix;
 
-		return $table_prefix;
+		return 'drupal_';
 	}
 
 	public function get_drupal_images_from_nid( int $nid ) {

--- a/src/Command/PublisherSpecific/CarsonNowMigrator.php
+++ b/src/Command/PublisherSpecific/CarsonNowMigrator.php
@@ -390,11 +390,11 @@ class CarsonNowMigrator implements InterfaceCommand {
 		}
 		$field_image = $result[0];
 
-		$img_url = 'https://www.carsonnow.org/' . $field_image['filepath'];
+		$img_url = trailingslashit( NCCM_SOURCE_WEBSITE_URL ) . $field_image['filepath'];
 
 		if ( $fallback_to_imagecache ) {
 			$request = wp_remote_head( $img_url, [ 'redirection' => 5 ] );
-			if ( empty( $request['response']['code'] ) || $request['response']['code'] === 404 ) {
+			if ( is_wp_error( $request ) || 404 === $request['response']['code'] ?? 404 ) {
 				$img_url = str_replace( '/files/', '/files/imagecache/galleryformatter_slide/', $img_url );
 			}
 		}

--- a/src/Command/PublisherSpecific/CarsonNowMigrator.php
+++ b/src/Command/PublisherSpecific/CarsonNowMigrator.php
@@ -227,10 +227,12 @@ class CarsonNowMigrator implements InterfaceCommand {
 			// Add the byline block to the beginning of the content.
 			array_unshift( $post_blocks, \Newspack_Content_Byline::get_post_meta_bound_byline_block() );
 
-			wp_update_post( [
-				'ID'           => $post->ID,
-				'post_content' => serialize_blocks( $post_blocks ),
-			] );
+			wp_update_post(
+				[
+					'ID'           => $post->ID,
+					'post_content' => serialize_blocks( $post_blocks ),
+				] 
+			);
 			// Set the byline as metadata too.
 			update_post_meta( $post->ID, \Newspack_Content_Byline::BYLINE_META_KEY, $drupal_byline );
 
@@ -467,7 +469,6 @@ class CarsonNowMigrator implements InterfaceCommand {
 		}
 
 		return $post_type;
-
 	}
 
 	public function fg_filter_get_node_types( $node_types ) {
@@ -515,16 +516,18 @@ class CarsonNowMigrator implements InterfaceCommand {
 				return self::SKIP_IMPORTING_POST;
 			}
 
-			$block         = serialize_block( [
-				'blockName'    => 'newspack-listings/event-dates',
-				'attrs'        => [
-					'startDate' => $date->format( self::WP_DATE_FORMAT ),
-					'showTime'  => true,
-				],
-				'innerBlocks'  => [],
-				'innerHTML'    => '',
-				'innerContent' => [],
-			] );
+			$block         = serialize_block(
+				[
+					'blockName'    => 'newspack-listings/event-dates',
+					'attrs'        => [
+						'startDate' => $date->format( self::WP_DATE_FORMAT ),
+						'showTime'  => true,
+					],
+					'innerBlocks'  => [],
+					'innerHTML'    => '',
+					'innerContent' => [],
+				] 
+			);
 			$date_blocks[] = $block;
 		}
 

--- a/src/Command/PublisherSpecific/CarsonNowMigrator.php
+++ b/src/Command/PublisherSpecific/CarsonNowMigrator.php
@@ -320,7 +320,7 @@ class CarsonNowMigrator implements InterfaceCommand {
 			if ( empty( $img_block['attrs']['className'] ) ) {
 				$img_block['attrs']['className'] = $img_block_class;
 			} else {
-				$img_block['attrs']['className'] .= ',' . $img_block_class;
+				$img_block['attrs']['className'] .= ' ' . $img_block_class;
 			}
 
 			$post->post_content = serialize_blocks( [ $img_block, ...$blocks ] );

--- a/src/Command/PublisherSpecific/CarsonNowMigrator.php
+++ b/src/Command/PublisherSpecific/CarsonNowMigrator.php
@@ -316,12 +316,7 @@ class CarsonNowMigrator implements InterfaceCommand {
 			}
 			$img_block_class = 'cn-gallery-1-img';
 			$blocks          = GutenbergBlockManipulator::remove_blocks_with_class( $img_block_class, $post->post_content );
-			$img_block       = $this->gutenberg_block_generator->get_image( $attachment_post, 'full', false );
-			if ( empty( $img_block['attrs']['className'] ) ) {
-				$img_block['attrs']['className'] = $img_block_class;
-			} else {
-				$img_block['attrs']['className'] .= ' ' . $img_block_class;
-			}
+			$img_block       = $this->gutenberg_block_generator->get_image( $attachment_post, 'full', false, $img_block_class );
 
 			$post->post_content = serialize_blocks( [ $img_block, ...$blocks ] );
 


### PR DESCRIPTION
This makes the Drupal migrator a bit more re-usable for other sites by using more env vars and making the database connection use env vars too so we can run on staging without having to touch passwords.

I also added convenience commands to composer.json for phpcs and phpcbf.

## How to test
- It's run already


