### PR TITLE
Use an actual release of NMT in composer to avoid confusion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "mustache/mustache": "^2.14",
     "simplehtmldom/simplehtmldom": "2.0-RC2",
     "automattic/newspack-scraper-migrator": "dev-trunk",
-    "automattic/newspack-migration-tools": "dev-trunk"
+    "automattic/newspack-migration-tools": "1.0.0"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95f212e287b86f9d84964dfbb9973e09",
+    "content-hash": "a3a94a5aa5ca2d33030d7c8c6f490602",
     "packages": [
         {
             "name": "automattic/newspack-content-converter",
@@ -43,31 +43,54 @@
         },
         {
             "name": "automattic/newspack-migration-tools",
-            "version": "dev-trunk",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/newspack-migration-tools.git",
-                "reference": "f61c7e0e804be24f63e3dc4e927fc21aa3218135"
+                "reference": "ddc236d3b8f7b4726faf28405e92c147e5f7b0e9"
+            },
+            "require": {
+                "php": ">=8.1"
             },
             "require-dev": {
                 "automattic/vipwpcs": "^3.0",
+                "php-coveralls/php-coveralls": "^2.7",
                 "phpcompatibility/phpcompatibility-wp": "*",
                 "phpunit/phpunit": "^9.6",
                 "wp-coding-standards/wpcs": "^3.0",
                 "yoast/phpunit-polyfills": "^2.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Newspack\\MigrationTools\\": "src/"
                 }
             },
+            "scripts": {
+                "phpcs": [
+                    "./vendor/bin/phpcs"
+                ],
+                "phpcbf": [
+                    "./vendor/bin/phpcbf"
+                ],
+                "phpunit": [
+                    "./vendor/bin/phpunit"
+                ],
+                "code-coverage": [
+                    "export XDEBUG_MODE=coverage && ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml"
+                ],
+                "build-release": [
+                    "rm -rf vendor",
+                    "rm -rf release",
+                    "composer install --no-dev --optimize-autoloader",
+                    "composer archive --format=zip --dir=release --file=newspack-migration-tools"
+                ]
+            },
             "license": [
                 "GPL-3.0-or-later"
             ],
             "description": "A set of tools to help migration to WordPress.",
-            "time": "2024-05-29T15:30:47+00:00"
+            "time": "2024-08-13T02:47:07+00:00"
         },
         {
             "name": "automattic/newspack-post-image-downloader",
@@ -4845,8 +4868,7 @@
         "automattic/newspack-post-image-downloader": 20,
         "automattic/newspack-content-converter": 20,
         "simplehtmldom/simplehtmldom": 5,
-        "automattic/newspack-scraper-migrator": 20,
-        "automattic/newspack-migration-tools": 20
+        "automattic/newspack-scraper-migrator": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
I was using `dev-trunk` to get the latest from the NMT. That got confusing really quick, so this starts us using releases instead. 

## How to test
- composer install and check that you can run some wp cli commands with no error.

---

- [ ] confirmed that PHPCS has been run
