### PR TITLE
Add phpcs check on code in PRs

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Remove private package
-        run: composer remove automattic/newspack-migration-tools --no-update
+        run: composer remove automattic/newspack-migration-tools
 
       - name: Install dependencies using the lock file
         run: composer install

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,22 @@
+name: PHP CodeSniffer on changed files
+
+on:
+  pull_request:
+    branches: [ trunk ]
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Run PHP CodeSniffer
+        run: |
+          git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} -- '*.php' | xargs -r composer run phpcs

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -14,12 +14,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install dependencies
+      - name: Check for PHP file changes
+        id: check_php_changes
         run: |
-          jq 'del(.require, .repositories)' composer.json > composer.dev.json
-          rm composer.lock
-          COMPOSER=composer.dev.json composer install --no-interaction --prefer-dist --no-progress --no-scripts --ignore-platform-reqs
+          CHANGED_PHP_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | grep '\.php$' || true)
+          echo "CHANGED_PHP_FILES=$CHANGED_PHP_FILES" >> $GITHUB_ENV
 
-      - name: Run PHP CodeSniffer
+      - name: Set flag for PHP file changes
         run: |
-          git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} -- '*.php' | xargs -r composer run phpcs
+          if [ -n "${{ env.CHANGED_PHP_FILES }}" ]; then
+            echo "php_files_changed=true" >> $GITHUB_ENV
+          else
+            echo "php_files_changed=false" >> $GITHUB_ENV
+          fi
+
+      - name: Install dependencies
+        if: ${{ env.php_files_changed == 'true' }}
+        run: composer install
+
+      - name: Run PHP CodeSniffer on changed files
+        if: ${{ env.php_files_changed == 'true' }}
+        run: |
+          ./vendor/bin/phpcs-changed --git --git-base ${{ github.event.pull_request.base.sha }} $(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} | grep '\.php$')

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -14,10 +14,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Remove private package
-        run: composer remove automattic/newspack-migration-tools
-
-      - name: Install dependencies using the lock file
+      - name: Install dependencies
         run: composer install
 
       - name: Run PHP CodeSniffer

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -15,7 +15,9 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
-        run: composer install
+        run: |
+          composer remove automattic/newspack-migration-tools --no-update
+          composer install
 
       - name: Run PHP CodeSniffer
         run: |

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -30,7 +30,10 @@ jobs:
 
       - name: Install dependencies
         if: ${{ env.php_files_changed == 'true' }}
-        run: composer install
+        run: |
+          jq 'del(.require, .repositories)' composer.json > composer.dev.json
+          rm composer.lock
+          COMPOSER=composer.dev.json composer install --no-interaction --prefer-dist --no-progress --no-scripts --ignore-platform-reqs
 
       - name: Run PHP CodeSniffer on changed files
         if: ${{ env.php_files_changed == 'true' }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -15,7 +15,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install dependencies
-        run: composer install
+        run: |
+          jq 'del(.require, .repositories)' composer.json > composer.dev.json
+          rm composer.lock
+          COMPOSER=composer.dev.json composer install --no-interaction --prefer-dist --no-progress --no-scripts --ignore-platform-reqs
 
       - name: Run PHP CodeSniffer
         run: |

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -14,10 +14,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install dependencies
-        run: |
-          composer remove automattic/newspack-migration-tools --no-update
-          composer install
+      - name: Remove private package
+        run: composer remove automattic/newspack-migration-tools --no-update
+
+      - name: Install dependencies using the lock file
+        run: composer install
 
       - name: Run PHP CodeSniffer
         run: |

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
     "composer/installers": "^1.7",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "yoast/phpunit-polyfills": "^1.0",
-    "phpunit/phpunit": "9.*"
+    "phpunit/phpunit": "9.*",
+    "sirbrillig/phpcs-changed": "^2.11"
   },
   "config": {
     "vendor-dir": "vendor",
@@ -77,6 +78,7 @@
   },
   "scripts": {
     "phpcs": "./vendor/bin/phpcs",
+    "phpcs-unstaged-diff": "./vendor/bin/phpcs-changed --git --git-unstaged $(git diff --name-only | grep '\\.php$') || true",
     "phpcbf": "./vendor/bin/phpcbf",
     "release": [
       "composer install --no-dev --optimize-autoloader",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95f212e287b86f9d84964dfbb9973e09",
+    "content-hash": "6194afe6334421d775d6d043f8b0fb77",
     "packages": [
         {
             "name": "automattic/newspack-content-converter",
@@ -4547,6 +4547,60 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-changed",
+            "version": "v2.11.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-changed.git",
+                "reference": "aaa144eb4f14697b6b06e3dcf74081b5a02f85f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/aaa144eb4f14697b6b06e3dcf74081b5a02f85f6",
+                "reference": "aaa144eb4f14697b6b06e3dcf74081b5a02f85f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "phpunit/phpunit": "^6.4 || ^9.5",
+                "sirbrillig/phpcs-variable-analysis": "^2.1.3",
+                "squizlabs/php_codesniffer": "^3.2.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "bin": [
+                "bin/phpcs-changed"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "PhpcsChanged/Cli.php",
+                    "PhpcsChanged/functions.php"
+                ],
+                "psr-4": {
+                    "PhpcsChanged\\": "PhpcsChanged/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.5"
+            },
+            "time": "2024-05-23T20:01:41+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",

--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -13,7 +13,7 @@
 namespace NewspackCustomContentMigrator;
 
 // Don't do anything outside WP CLI.
-if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+if (!defined( 'WP_CLI' ) || ! WP_CLI ){
 	return;
 }
 

--- a/newspack-custom-content-migrator.php
+++ b/newspack-custom-content-migrator.php
@@ -13,7 +13,7 @@
 namespace NewspackCustomContentMigrator;
 
 // Don't do anything outside WP CLI.
-if (!defined( 'WP_CLI' ) || ! WP_CLI ){
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
 


### PR DESCRIPTION
This GH action will run phpcs on the code touched in PRs. 

It has to do some juggling of json in the composer file to (lazily) avoid the private repositories in there, but since we only need the stuff in `require-dev` for running phpcs we should be fine.

## How to test
The easiest way to test is to push a change with some borked formatting in a PHP file and see the result, so there is a file that has that in here. I'll remove that before merging.