### PR TITLE
Image block with custom link (from old PR#324)

### DIFF
--- a/src/Logic/GutenbergBlockGenerator.php
+++ b/src/Logic/GutenbergBlockGenerator.php
@@ -248,13 +248,14 @@ class GutenbergBlockGenerator {
 	 *
 	 * @param \WP_Post $attachment_post        Image Post.
 	 * @param string   $size                   Image size, full by default.
-	 * @param bool     $link_to_attachment_url Whether to link to the attachment URL or not.
-	 * @param string   $classname              Media HTML class.
-	 * @param string   $align                  Image alignment (left, right).
+	 * @param ?bool    $link_to_attachment_url Whether to link to the attachment URL or not. Defaults to true.
+	 * @param ?string  $classname              Media HTML class.
+	 * @param ?string  $align                  Image alignment (left, right).
+	 * @param ?string  $custom_link            If provided, will set custom link. Overrides $link_to_attachment_url.
 	 *
 	 * @return array to be used in the serialize_blocks function to get the raw content of a Gutenberg Block.
 	 */
-	public function get_image( $attachment_post, $size = 'full', $link_to_attachment_url = true, $classname = null, $align = null ) {
+	public function get_image( $attachment_post, $size = 'full', $link_to_attachment_url = true, $classname = null, $align = null, $custom_link = null ) {
 		// Validate size.
 		if ( ! in_array( $size, [ 'thumbnail', 'medium', 'large', 'full' ] ) ) {
 			$size = 'full';
@@ -273,8 +274,14 @@ class GutenbergBlockGenerator {
 		// Add <a> link to attachment URL.
 		$a_opening_tag = '';
 		$a_closing_tag = '';
-		if ( $link_to_attachment_url ) {
-			$a_opening_tag = sprintf( '<a href="%s">', $image_url );
+		if ( $custom_link || $link_to_attachment_url ) {
+			if ( $custom_link ) {
+				$link = $custom_link;
+			} elseif ( $link_to_attachment_url ) {
+				$link = $image_url;
+			}
+
+			$a_opening_tag = sprintf( '<a href="%s">', $link );
 			$a_closing_tag = '</a>';
 		}
 


### PR DESCRIPTION
Gutenberg helper class's `get_image` which returns an Image block, now gets the ability to not only use `$link_to_attachment_url` but also a `$custom_link`. The image block can normally use both these links.