### PR TITLE
CDiff migrates all WP_Users

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Description
-About these changes.
+About changes in this PR...
 
 ## How to test
 - ... proposed steps and scenarios...

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,3 +1,6 @@
+## Description
+About these changes.
+
 ## How to test
 - ... proposed steps and scenarios...
 

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -403,6 +403,10 @@ class ContentDiffMigrator implements InterfaceCommand {
 		$export_dir        = $assoc_args['export-dir'] ?? false;
 		$live_table_prefix = $assoc_args['live-table-prefix'] ?? false;
 		$post_types        = isset( $assoc_args['post-types-csv'] ) ? explode( ',', $assoc_args['post-types-csv'] ) : [ 'post', 'attachment' ];
+		// Disable CAP's "guest-author" CPT.
+		if ( in_array( 'guest-author', $post_types ) ) {
+			WP_CLI::error( "CAP's 'guest-author' CPT is not supported at this point as CAP data requires a dedicated migrator for its complexity and special cases. Please remove 'guest-author' from the list of CPTs to migrate and re-run the command." );
+		}
 
 		global $wpdb;
 		try {

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -635,14 +635,29 @@ class ContentDiffMigrator implements InterfaceCommand {
 		if ( file_exists( $this->log_error ) ) {
 			$cli_output_logs_report[] = sprintf( '%s - errors', $this->log_error );
 		}
+		if ( file_exists( $this->log_deleted_modified_ids ) ) {
+			$cli_output_logs_report[] = sprintf( '%s - all modified post IDs', $this->log_deleted_modified_ids );
+		}
 		if ( file_exists( $this->log_imported_post_ids ) ) {
 			$cli_output_logs_report[] = sprintf( '%s - all imported IDs', $this->log_imported_post_ids );
+		}
+		if ( file_exists( $this->log_recreated_hierarchical_taxonomies ) ) {
+			$cli_output_logs_report[] = sprintf( '%s - created taxonomies', $this->log_recreated_hierarchical_taxonomies );
+		}
+		if ( file_exists( $this->log_inserted_wp_users ) ) {
+			$cli_output_logs_report[] = sprintf( '%s - created WP_Users', $this->log_inserted_wp_users );
 		}
 		if ( file_exists( $this->log_updated_blocks_ids ) ) {
 			$cli_output_logs_report[] = sprintf( '%s - detailed blocks IDs post content replacements', $this->log_updated_blocks_ids );
 		}
+		if ( file_exists( $this->log_updated_posts_parent_ids ) ) {
+			$cli_output_logs_report[] = sprintf( '%s - post_parent IDs updates', $this->log_updated_posts_parent_ids );
+		}
+		if ( file_exists( $this->log_updated_featured_imgs_ids ) ) {
+			$cli_output_logs_report[] = sprintf( '%s - featured image IDs updates', $this->log_updated_featured_imgs_ids );
+		}
 		if ( ! empty( $cli_output_logs_report ) ) {
-			WP_CLI::log( 'Check the logs for more details:' );
+			WP_CLI::success( 'Check the logs for more details:' );
 			WP_CLI::log( '- ' . implode( "\n- ", $cli_output_logs_report ) );
 		}
 

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -579,6 +579,10 @@ class ContentDiffMigrator implements InterfaceCommand {
 		WP_CLI::log( sprintf( 'Recreating taxonomies %s ...', "\n- " . implode( "\n- ", $taxonomies_to_recreate ) ) );
 		$hierarchical_taxonomy_term_id_updates = $this->recreate_hierarchical_taxonomies( $taxonomies_to_recreate );
 
+		// Migrate all WP_Users (for WooComm data).
+		WP_CLI::log( 'Migrating all WP_Users...' );
+		self::$logic->migrate_all_users( $live_table_prefix );
+
 		if ( ! empty( $all_live_modified_posts_data ) ) {
 			WP_CLI::log( sprintf( 'Deleting %s modified posts before they are reimported...', count( $all_live_modified_posts_data ) ) );
 		}

--- a/src/Command/General/ContentDiffMigrator.php
+++ b/src/Command/General/ContentDiffMigrator.php
@@ -28,6 +28,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 	const LOG_UPDATED_BLOCKS_IDS                = 'content-diff__wp-blocks-ids-updates.log';
 	const LOG_ERROR                             = 'content-diff__err.log';
 	const LOG_RECREATED_HIERARCHICAL_TAXONOMIES = 'content-diff__recreated_hierarchical_taxonomies.log';
+	const LOG_INSERTED_WP_USERS                 = 'content-diff__inserted_wp_users.log';
 
 	/**
 	 * Instance.
@@ -63,6 +64,13 @@ class ContentDiffMigrator implements InterfaceCommand {
 	 * @var null|string Full path to file.
 	 */
 	private $log_recreated_hierarchical_taxonomies;
+	
+	/**
+	 * Log containing inserted WP_User IDs.
+	 *
+	 * @var null|string Full path to file.
+	 */
+	private $log_inserted_wp_users;
 
 	/**
 	 * Log containing imported post IDs.
@@ -548,6 +556,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 		$this->live_table_prefix                     = $live_table_prefix;
 		$this->log_error                             = $import_dir . '/' . self::LOG_ERROR;
 		$this->log_recreated_hierarchical_taxonomies = $import_dir . '/' . self::LOG_RECREATED_HIERARCHICAL_TAXONOMIES;
+		$this->log_inserted_wp_users                 = $import_dir . '/' . self::LOG_INSERTED_WP_USERS;
 		$this->log_imported_post_ids                 = $import_dir . '/' . self::LOG_IMPORTED_POST_IDS;
 		$this->log_updated_posts_parent_ids          = $import_dir . '/' . self::LOG_UPDATED_PARENT_IDS;
 		$this->log_deleted_modified_ids              = $import_dir . '/' . self::LOG_DELETED_MODIFIED_IDS;
@@ -581,7 +590,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 
 		// Migrate all WP_Users (for WooComm data).
 		WP_CLI::log( 'Migrating all WP_Users...' );
-		self::$logic->migrate_all_users( $live_table_prefix );
+		$this->migrate_all_users( $live_table_prefix );
 
 		if ( ! empty( $all_live_modified_posts_data ) ) {
 			WP_CLI::log( sprintf( 'Deleting %s modified posts before they are reimported...', count( $all_live_modified_posts_data ) ) );
@@ -785,7 +794,7 @@ class ContentDiffMigrator implements InterfaceCommand {
 	 */
 	public function recreate_hierarchical_taxonomies( $taxonomies_to_migrate ) {
 		$hierarchical_taxonomy_term_id_updates = self::$logic->recreate_hierarchical_taxonomies( $this->live_table_prefix, $taxonomies_to_migrate );
-
+		
 		// Log taxonomy term_id updates.
 		$this->log(
 			$this->log_recreated_hierarchical_taxonomies,
@@ -793,6 +802,24 @@ class ContentDiffMigrator implements InterfaceCommand {
 		);
 
 		return $hierarchical_taxonomy_term_id_updates;
+	}
+
+	/**
+	 * Migrates all WP_Users from Live to local.
+	 * 
+	 * @param string $live_table_prefix Live table prefix.
+	 * @return array Map of newly inserted WP_Users, keys are old Live IDs and values are new local IDs.
+	 */
+	public function migrate_all_users( $live_table_prefix ) {
+		$inserted_wp_users_updates = self::$logic->migrate_all_users( $live_table_prefix );
+
+		// Log taxonomy term_id updates.
+		$this->log(
+			$this->log_inserted_wp_users,
+			wp_json_encode( [ 'inserted_wp_users_updates' => $inserted_wp_users_updates ] )
+		);
+
+		return $inserted_wp_users_updates;
 	}
 
 	/**

--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -917,7 +917,7 @@ class ContentDiffMigrator {
 		foreach ( $users_rows as $user_row ) {
 			// Skip if user exists.
 			$user_existing = $this->get_user_by( 'login', $user_row['user_login'] );
-			if ( $user_existing instanceof WP_User || false == $user_existing ) {
+			if ( $user_existing instanceof WP_User ) {
 				continue;
 			}
 

--- a/src/Logic/ContentDiffMigrator.php
+++ b/src/Logic/ContentDiffMigrator.php
@@ -900,13 +900,13 @@ class ContentDiffMigrator {
 	}
 
 	/**
-	 * Recreates all hierarchical or non-hierarchical taxonomies from Live to local.
+	 * Migrates all users from Live tables to local tables.
 	 *
 	 * @param string $live_table_prefix Live DB table prefix.
 	 *
 	 * @return array Map of all newly inserted users. Keys are Live wp_user.ID's, and values are newly inserted user IDs.
 	 * 
-	 * @throws RuntimeException If user insertion fails, thrown by insert_usermeta_row and insert_user.
+	 * @throws RuntimeException If user insertion fails, gets thrown by insert_usermeta_row and insert_user.
 	 */
 	public function migrate_all_users( $live_table_prefix ) {
 		


### PR DESCRIPTION
## Description
Before this PR only those WP_Users which are authors to posts were migrated. This change migrates all the WP_Users so that WooComm subscribers have their user objects automatically migrated as well.

## Branch
This PR was branched off of #516 `feat/import-custom-taxonomies-with-cdiff`. Therefore when merging, make sure to merge #516 first, then if there were any new changes on `feat/import-custom-taxonomies-with-cdiff` merge them into this branch, and only then merge this branch.

## How to test
- create two test sites, one to emulate the Live site, another to emulate the Staging site
- run a Content Diff scenario,
  - put some content on Live site
  - make Staging site as a clone of the Live site
  - next, put some new content on the Live site:
    - create several WP_Users, some authors to posts, others not authors to posts, with different roles
    - add several user meta rows to wp_usermeta for these new users
  - bring in new Live site's SQL dump with cdiff_ table prefix into the Staging site
  - run the two Content Diff commands
  - check that all the users were inserted correctly into the Staging site

---

- [x] confirmed that PHPCS has been run
