### PR TITLE
Make code php 8.3 compliant

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,7 +13,7 @@
 	</rule>
 
 	<rule ref="PHPCompatibilityWP"/>
-	<config name="testVersion" value="7.4"/>
+	<config name="testVersion" value="8.3"/>
 
 	<arg name="extensions" value="php"/>
 
@@ -21,7 +21,7 @@
 	<arg value="s"/>
 
 	<!-- Allow invoking just `phpcs` on command line without assuming STDIN for file input. -->
-	<file>.</file>
+	<file>src</file>
+	<file>tests</file>
 
-	<exclude-pattern>*/vendor/*</exclude-pattern>
 </ruleset>

--- a/src/Command/PublisherSpecific/CarsonNowMigrator.php
+++ b/src/Command/PublisherSpecific/CarsonNowMigrator.php
@@ -359,7 +359,7 @@ class CarsonNowMigrator implements RegisterCommandInterface {
 	public function get_image_data_from_fid( $fid, $fallback_to_imagecache = true ): array {
 		$prefix = $this->get_prefix();
 		global $wpdb;
-		$result = $wpdb->get_results( "SELECT * FROM ${prefix}files WHERE fid = $fid", ARRAY_A );
+		$result = $wpdb->get_results( "SELECT * FROM {$prefix}files WHERE fid = $fid", ARRAY_A );
 		if ( empty( $result ) ) {
 			return [];
 		}
@@ -585,7 +585,7 @@ class CarsonNowMigrator implements RegisterCommandInterface {
 			$post = get_post( $post_id );
 			if ( $post instanceof \WP_Post ) {
 				if ( $log_progress ) {
-					WP_CLI::log( sprintf( 'Processing post %d/%d: %s', ++$counter, $total_posts, "${home_url}?p=${post_id}" ) );
+					WP_CLI::log( sprintf( 'Processing post %d/%d: %s', ++$counter, $total_posts, "{$home_url}?p={$post_id}" ) );
 				}
 				yield $post;
 			}

--- a/src/Utils/ConsoleColor.php
+++ b/src/Utils/ConsoleColor.php
@@ -765,7 +765,7 @@ class ConsoleColor {
 		$text_sanitized = wp_kses( $text, wp_kses_allowed_html( 'post' ) );
 
 		if ( array_key_exists( $property, $this->$type ) ) {
-			$text_sanitized = $this->$type[ $property ] . $text_sanitized . '%n';
+			$text_sanitized = $this->{$type}[ $property ] . $text_sanitized . '%n';
 		}
 
 		return $text_sanitized;


### PR DESCRIPTION
## Description
We had a few lines that would fatal in PHP 8.3. This fixes that. It also changes the version phpcs checks against.

## How to test
- Run:
  -  `composer run-script phpcs -- -p --standard=PHPCompatibility --runtime-set testVersion 8.1 src`
  -  `composer run-script phpcs -- -p --standard=PHPCompatibility --runtime-set testVersion 8.1 tests`
  -  `composer run-script phpcs -- -p --standard=PHPCompatibility --runtime-set testVersion 8.3 src`
  -  `composer run-script phpcs -- -p --standard=PHPCompatibility --runtime-set testVersion 8.3 tests`
  - They should all come back with no errors.

