### PR TITLE
fix: this fix ensures that `user_email` will always have a value.

### DIFF
--- a/src/Command/General/VillageMediaCMSMigrator.php
+++ b/src/Command/General/VillageMediaCMSMigrator.php
@@ -1083,9 +1083,15 @@ class VillageMediaCMSMigrator implements RegisterCommandInterface {
 			if ( ! empty( $author_data['user_login'] ) ) {
 				$author_data['user_email'] = $author_data['user_login'] . '@example.com';
 			} else {
-				// If user_login is also empty, generate a random email.
-				$author_data['user_email'] = 'author_' . wp_generate_password( 8, false ) . '@example.com';
+				// If user_login is also empty, use the original author ID.
+				$author_data['user_email'] = $author_data['meta_input']['original_author_id'] . '@example.com';
 			}
+		}
+
+		if ( '@example.com' === trim( $author_data['user_email'] ) ) {
+			WP_CLI::warning( 'ORIGINAL EMAIL FIELD IS BLANK. Unable to obtain a unique email for this author.' );
+			WP_CLI::log( implode( ' | ', $author_data ) );
+			$author_data['user_email'] = '';
 		}
 
 		return $author_data;

--- a/src/Command/General/VillageMediaCMSMigrator.php
+++ b/src/Command/General/VillageMediaCMSMigrator.php
@@ -1078,6 +1078,16 @@ class VillageMediaCMSMigrator implements RegisterCommandInterface {
 			}
 		}
 
+		// Ensure user_email is not blank.
+		if ( empty( $author_data['user_email'] ) ) {
+			if ( ! empty( $author_data['user_login'] ) ) {
+				$author_data['user_email'] = $author_data['user_login'] . '@example.com';
+			} else {
+				// If user_login is also empty, generate a random email.
+				$author_data['user_email'] = 'author_' . wp_generate_password( 8, false ) . '@example.com';
+			}
+		}
+
 		return $author_data;
 	}
 


### PR DESCRIPTION
## Description
We discovered that various authors were created without emails. This presents a problem as email is a very required field for WP. This small fix ensures that we always have an email for data migrated from Village Media.

## How to test
- ... proposed steps and scenarios...
1. Use a previous export from a Village Media CMS.
2. Pick an author, and ensure that you remove any references to their email.
3. Run the import migration on that export file.
4. Observe that although you removed their email, the user now has an email populated.
5. Now remove both email and username fields from export.
6. Re-import the data.
7. Notice that the migration is now throwing a warning showing that the email field for that user is blank.

- [X] confirmed that PHPCS has been run
