### PR TITLE
fix: issue where EOF is reached prematurely, and `get_row` returns bool

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -55,12 +55,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/newspack-migration-tools.git",
-                "reference": "6c7189e93a4cdcfc8022354766293d69241dd926"
+                "reference": "921a2c9defe755641ebdce3753dd76ea61c38d5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/6c7189e93a4cdcfc8022354766293d69241dd926",
-                "reference": "6c7189e93a4cdcfc8022354766293d69241dd926",
+                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/921a2c9defe755641ebdce3753dd76ea61c38d5b",
+                "reference": "921a2c9defe755641ebdce3753dd76ea61c38d5b",
                 "shasum": ""
             },
             "require": {
@@ -114,7 +114,7 @@
                 "source": "https://github.com/Automattic/newspack-migration-tools/tree/trunk",
                 "issues": "https://github.com/Automattic/newspack-migration-tools/issues"
             },
-            "time": "2025-02-18T14:41:40+00:00"
+            "time": "2025-03-13T15:39:36+00:00"
         },
         {
             "name": "automattic/newspack-post-image-downloader",
@@ -5343,15 +5343,15 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "automattic/newspack-post-image-downloader": 20,
         "automattic/newspack-content-converter": 20,
-        "simplehtmldom/simplehtmldom": 5,
+        "automattic/newspack-migration-tools": 20,
+        "automattic/newspack-post-image-downloader": 20,
         "automattic/newspack-scraper-migrator": 20,
-        "automattic/newspack-migration-tools": 20
+        "simplehtmldom/simplehtmldom": 5
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/Utils/CommonDataFileIterator/CSVFile.php
+++ b/src/Utils/CommonDataFileIterator/CSVFile.php
@@ -82,7 +82,13 @@ class CSVFile extends AbstractIterableFile implements CSVFileInterface {
 	public function get_header(): array {
 		rewind( $this->get_handle() );
 
-		return $this->get_row( $this->get_handle() );
+		$row = $this->get_row( $this->get_handle() );
+
+		if ( is_bool( $row ) ) {
+			throw new Exception( 'File does not exist or is not readable.' );
+		}
+
+		return $row;
 	}
 
 	/**
@@ -99,7 +105,11 @@ class CSVFile extends AbstractIterableFile implements CSVFileInterface {
 
 		$row_count = 1;
 		while ( $row_count < $this->get_start() ) {
-			$this->get_row( $handle ); // Move the file handle to the desired starting position.
+			$row = $this->get_row( $handle ); // Move the file handle to the desired starting position.
+
+			if ( is_bool( $row ) ) { // We've somehow reached the end of the file before reaching the starting position.
+				return;
+			}
 
 			if ( feof( $handle ) ) {
 				yield [];
@@ -111,6 +121,10 @@ class CSVFile extends AbstractIterableFile implements CSVFileInterface {
 
 		while ( $row_count <= $this->get_end() && ! feof( $handle ) ) {
 			$raw_row = $this->get_row( $handle );
+
+			if ( is_bool( $raw_row ) ) {
+				return;
+			}
 
 			if ( count( $raw_row ) !== $header_count ) {
 				throw new Exception(
@@ -229,9 +243,11 @@ class CSVFile extends AbstractIterableFile implements CSVFileInterface {
 	 * Convenience function to facilitate obtaining a CSV row.
 	 *
 	 * @param resource $handle The open file handle for the CSV file.
+	 *
+	 * @return array|bool The CSV row, or false if end of file is reached.
 	 * @throws Exception Exception thrown if $handle is not a resource.
 	 */
-	protected function get_row( $handle ): array {
+	protected function get_row( $handle ): array|bool {
 		if ( ! is_resource( $handle ) ) {
 			throw new Exception( '$handle is not a resource.' );
 		}


### PR DESCRIPTION
## Description
There are some CSV files that have an extra line item at the end of it. It's empty though. But this means that `feof` returns `false` though. This then then leads to trying to get this row with `get_row` and the `fgetcsv` call returning `false` instead of an expected array.

These changes will now let `get_row` to return `bool` (which can happen when calling `fgetcsv`), and when a `bool` is received, it means we have reached the end of file, there are no more rows to process, so we should either return/exit out of the current function or throw an Exception.

## How to test
1. Open the attached CSV:
> $csv = new \NewspackCustomContentMigrator\Utils\CommonDataFileIterator\CSVFile( $path_to_file );
2. Get an iterator:
> $it = $csv->getIterator();
3. Loop through, see that an PHP fatal is thrown before reaching the end of file
> foreach( $it as $row ) {
>    var_dump( $row );
> }
4. Check out this PR/branch
5. Repeat steps 1-3, notice that the end of file is reached and no fatal is thrown.
[test.csv](https://github.com/user-attachments/files/19656098/test.csv)


---

- [X] confirmed that PHPCS has been run
